### PR TITLE
Renovate heap system to avoid polluting object

### DIFF
--- a/IntegrationTests/TestSuites/Sources/BenchmarkTests/main.swift
+++ b/IntegrationTests/TestSuites/Sources/BenchmarkTests/main.swift
@@ -19,3 +19,15 @@ serialization.testSuite("Swift String to JavaScript") {
         object.set("stringValue\(i)", jsString)
     }
 }
+
+
+let objectHeap = Benchmark("Object heap")
+
+let global = JSObjectRef.global
+let Object = global.Object.function!
+global.objectHeapDummy = .object(Object.new())
+objectHeap.testSuite("Increment and decrement RC") {
+    for _ in 0 ..< 100 {
+        _ = global.objectHeapDummy
+    }
+}


### PR DESCRIPTION
Resolve https://github.com/swiftwasm/JavaScriptKit/issues/18

Before

```
Running 'Serialization/Write JavaScript number directly' ...
done 120.80175709724426 ms
Running 'Serialization/Write JavaScript string directly' ...
done 122.2523729801178 ms
Running 'Serialization/Swift Int to JavaScript' ...
done 3196.50106716156 ms
Running 'Serialization/Swift String to JavaScript' ...
done 4943.781615972519 ms
Running 'Object heap/Increment and decrement RC' ...
done 3109.1712770462036 ms
```

After 
```
Running 'Serialization/Write JavaScript number directly' ...
done 119.7573311328888 ms
Running 'Serialization/Write JavaScript string directly' ...
done 124.71527099609375 ms
Running 'Serialization/Swift Int to JavaScript' ...
done 3120.5893318653107 ms
Running 'Serialization/Swift String to JavaScript' ...
done 4833.4492201805115 ms
Running 'Object heap/Increment and decrement RC' ...
done 2962.947032928467 ms
```