### PR TITLE
Pass around a DataView instead of individual kind/payload fields

### DIFF
--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -247,8 +247,7 @@ export class SwiftRuntime {
         }
 
         // Note:
-        // `decodeValues` assumes that the size of RawJSValue is 24
-        // and the alignment of it is 8
+        // `decodeValues` assumes that the size of RawJSValue is 12
         const decodeValues = (ptr: pointer, length: number) => {
             let result = []
             for (let index = 0; index < length; index++) {

--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -180,7 +180,8 @@ export class SwiftRuntime {
                       dataView.getUint32(payload2_ptr, true)
                     );
                 }
-                case JavaScriptValueKind.Object: {
+                case JavaScriptValueKind.Object:
+                case JavaScriptValueKind.Function: {
                     return this.heap.referenceHeap(dataView.getUint32(payload1_ptr, true))
                 }
                 case JavaScriptValueKind.Null: {
@@ -188,9 +189,6 @@ export class SwiftRuntime {
                 }
                 case JavaScriptValueKind.Undefined: {
                     return undefined
-                }
-                case JavaScriptValueKind.Function: {
-                    return this.heap.referenceHeap(dataView.getUint32(payload1_ptr, true))
                 }
                 default:
                     throw new Error(`Type kind "${kind}" is not supported`)

--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -155,24 +155,9 @@ export class SwiftRuntime {
             }
         }
 
-        const readUInt32 = (ptr: pointer) => {
-            const uint32Memory = new Uint32Array(memory().buffer, ptr, 1);
-            return uint32Memory[0];
-        }
-
-        const readFloat64 = (ptr: pointer) => {
-            const dataView = new DataView(memory().buffer);
-            return dataView.getFloat64(ptr, true);
-        }
-
         const writeUint32 = (ptr: pointer, value: number) => {
             const uint32Memory = new Uint32Array(memory().buffer, ptr);
             uint32Memory[0] = (value & 0xffffffff);
-        }
-
-        const writeFloat64 = (ptr: pointer, value: number) => {
-            const dataView = new DataView(memory().buffer);
-            dataView.setFloat64(ptr, value, true);
         }
 
         const decodeValue = (dataView: DataView) => {

--- a/Sources/JavaScriptKit/JSFunction.swift
+++ b/Sources/JavaScriptKit/JSFunction.swift
@@ -9,10 +9,7 @@ public class JSFunctionRef: JSObjectRef {
                 let argv = bufferPointer.baseAddress
                 let argc = bufferPointer.count
                 var result = RawJSValue()
-                _call_function(
-                    self.id, argv, Int32(argc),
-                    &result.kind, &result.payload1, &result.payload2, &result.payload3
-                )
+                _call_function(self.id, argv, Int32(argc), &result)
                 return result
             }
         }
@@ -29,9 +26,7 @@ public class JSFunctionRef: JSObjectRef {
                 let argv = bufferPointer.baseAddress
                 let argc = bufferPointer.count
                 var result = RawJSValue()
-                _call_function_with_this(this.id,
-                                         self.id, argv, Int32(argc),
-                                         &result.kind, &result.payload1, &result.payload2, &result.payload3)
+                _call_function_with_this(this.id, self.id, argv, Int32(argc), &result)
                 return result
             }
         }

--- a/Sources/JavaScriptKit/JSValue.swift
+++ b/Sources/JavaScriptKit/JSValue.swift
@@ -71,30 +71,24 @@ extension JSValue: ExpressibleByIntegerLiteral {
 
 public func getJSValue(this: JSObjectRef, name: String) -> JSValue {
     var rawValue = RawJSValue()
-    _get_prop(this.id, name, Int32(name.count),
-              &rawValue.kind,
-              &rawValue.payload1, &rawValue.payload2, &rawValue.payload3)
+    _get_prop(this.id, name, Int32(name.count), &rawValue)
     return rawValue.jsValue()
 }
 
 public func setJSValue(this: JSObjectRef, name: String, value: JSValue) {
     value.withRawJSValue { rawValue in
-        _set_prop(this.id, name, Int32(name.count), rawValue.kind, rawValue.payload1, rawValue.payload2, rawValue.payload3)
+        _set_prop(this.id, name, Int32(name.count), &rawValue)
     }
 }
 
 public func getJSValue(this: JSObjectRef, index: Int32) -> JSValue {
     var rawValue = RawJSValue()
-    _get_subscript(this.id, index,
-                   &rawValue.kind,
-                   &rawValue.payload1, &rawValue.payload2, &rawValue.payload3)
+    _get_subscript(this.id, index, &rawValue)
     return rawValue.jsValue()
 }
 
 public func setJSValue(this: JSObjectRef, index: Int32, value: JSValue) {
     value.withRawJSValue { rawValue in
-        _set_subscript(this.id, index,
-                       rawValue.kind,
-                       rawValue.payload1, rawValue.payload2, rawValue.payload3)
+        _set_subscript(this.id, index, &rawValue)
     }
 }

--- a/Sources/JavaScriptKit/XcodeSupport.swift
+++ b/Sources/JavaScriptKit/XcodeSupport.swift
@@ -9,34 +9,22 @@ import _CJavaScriptKit
     func _set_prop(
         _: JavaScriptObjectRef,
         _: UnsafePointer<Int8>!, _: Int32,
-        _: JavaScriptValueKind,
-        _: JavaScriptPayload1,
-        _: JavaScriptPayload2,
-        _: JavaScriptPayload3
+        _: UnsafePointer<RawJSValue>!
     ) { fatalError() }
     func _get_prop(
         _: JavaScriptObjectRef,
         _: UnsafePointer<Int8>!, _: Int32,
-        _: UnsafeMutablePointer<JavaScriptValueKind>!,
-        _: UnsafeMutablePointer<JavaScriptPayload1>!,
-        _: UnsafeMutablePointer<JavaScriptPayload2>!,
-        _: UnsafeMutablePointer<JavaScriptPayload3>!
+        _: UnsafePointer<RawJSValue>!
     ) { fatalError() }
     func _set_subscript(
         _: JavaScriptObjectRef,
         _: Int32,
-        _: JavaScriptValueKind,
-        _: JavaScriptPayload1,
-        _: JavaScriptPayload2,
-        _: JavaScriptPayload3
+        _: UnsafePointer<RawJSValue>!
     ) { fatalError() }
     func _get_subscript(
         _: JavaScriptObjectRef,
         _: Int32,
-        _: UnsafeMutablePointer<JavaScriptValueKind>!,
-        _: UnsafeMutablePointer<JavaScriptPayload1>!,
-        _: UnsafeMutablePointer<JavaScriptPayload2>!,
-        _: UnsafeMutablePointer<JavaScriptPayload3>!
+        _: UnsafePointer<RawJSValue>!
     ) { fatalError() }
     func _load_string(
         _: JavaScriptObjectRef,
@@ -45,19 +33,13 @@ import _CJavaScriptKit
     func _call_function(
         _: JavaScriptObjectRef,
         _: UnsafePointer<RawJSValue>!, _: Int32,
-        _: UnsafeMutablePointer<JavaScriptValueKind>!,
-        _: UnsafeMutablePointer<JavaScriptPayload1>!,
-        _: UnsafeMutablePointer<JavaScriptPayload2>!,
-        _: UnsafeMutablePointer<JavaScriptPayload3>!
+        _: UnsafePointer<RawJSValue>!
     ) { fatalError() }
     func _call_function_with_this(
         _: JavaScriptObjectRef,
         _: JavaScriptObjectRef,
         _: UnsafePointer<RawJSValue>!, _: Int32,
-        _: UnsafeMutablePointer<JavaScriptValueKind>!,
-        _: UnsafeMutablePointer<JavaScriptPayload1>!,
-        _: UnsafeMutablePointer<JavaScriptPayload2>!,
-        _: UnsafeMutablePointer<JavaScriptPayload3>!
+        _: UnsafePointer<RawJSValue>!
     ) { fatalError() }
     func _call_new(
         _: JavaScriptObjectRef,

--- a/Sources/_CJavaScriptKit/include/_CJavaScriptKit.h
+++ b/Sources/_CJavaScriptKit/include/_CJavaScriptKit.h
@@ -25,35 +25,28 @@ typedef struct {
   JavaScriptValueKind kind;
   JavaScriptPayload1 payload1;
   JavaScriptPayload2 payload2;
-  JavaScriptPayload3 payload3;
 } RawJSValue;
 
 #if __wasm32__
 __attribute__((__import_module__("javascript_kit"),
                __import_name__("swjs_set_prop"))) extern void
 _set_prop(const JavaScriptObjectRef _this, const char *prop, const int length,
-          const JavaScriptValueKind kind, const JavaScriptPayload1 payload1,
-          const JavaScriptPayload2 payload2, const JavaScriptPayload3 payload3);
+          const RawJSValue *rawJSValue);
 
 __attribute__((__import_module__("javascript_kit"),
                __import_name__("swjs_get_prop"))) extern void
 _get_prop(const JavaScriptObjectRef _this, const char *prop, const int length,
-          JavaScriptValueKind *kind, JavaScriptPayload1 *payload1,
-          JavaScriptPayload2 *payload2, JavaScriptPayload3 *payload3);
+          const RawJSValue *rawJSValue);
 
 __attribute__((__import_module__("javascript_kit"),
                __import_name__("swjs_set_subscript"))) extern void
 _set_subscript(const JavaScriptObjectRef _this, const int length,
-               const JavaScriptValueKind kind,
-               const JavaScriptPayload1 payload1,
-               const JavaScriptPayload2 payload2,
-               const JavaScriptPayload3 payload3);
+               const RawJSValue *rawJSValue);
 
 __attribute__((__import_module__("javascript_kit"),
                __import_name__("swjs_get_subscript"))) extern void
 _get_subscript(const JavaScriptObjectRef _this, const int length,
-               JavaScriptValueKind *kind, JavaScriptPayload1 *payload1,
-               JavaScriptPayload2 *payload2, JavaScriptPayload3 *payload3);
+               const RawJSValue *rawJSValue);
 
 __attribute__((__import_module__("javascript_kit"),
                __import_name__("swjs_load_string"))) extern void
@@ -62,20 +55,14 @@ _load_string(const JavaScriptObjectRef ref, unsigned char *buffer);
 __attribute__((__import_module__("javascript_kit"),
                __import_name__("swjs_call_function"))) extern void
 _call_function(const JavaScriptObjectRef ref, const RawJSValue *argv,
-               const int argc, JavaScriptValueKind *result_kind,
-               JavaScriptPayload1 *result_payload1,
-               JavaScriptPayload2 *result_payload2,
-               JavaScriptPayload3 *result_payload3);
+               const int argc, const RawJSValue *rawJSValue);
 
 __attribute__((__import_module__("javascript_kit"),
                __import_name__("swjs_call_function_with_this"))) extern void
 _call_function_with_this(const JavaScriptObjectRef _this,
                          const JavaScriptObjectRef func_ref,
                          const RawJSValue *argv, const int argc,
-                         JavaScriptValueKind *result_kind,
-                         JavaScriptPayload1 *result_payload1,
-                         JavaScriptPayload2 *result_payload2,
-                         JavaScriptPayload3 *result_payload3);
+                         const RawJSValue *rawJSValue);
 
 __attribute__((__import_module__("javascript_kit"),
                __import_name__("swjs_call_new"))) extern void


### PR DESCRIPTION
Also change memory layout for numbers:

There are now only two payload slots. Numbers use them as a single Double, while every other type just uses them as two UInt32s

Originally part of #22.