### PR TITLE
Implement `RandomAccessCollection` on `JSArrayRef`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 dist
 node_modules
 .DS_Store
-/.build
+.build
 /Packages
 /*.xcodeproj
 xcuserdata/

--- a/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
+++ b/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
@@ -100,6 +100,17 @@ Array_Iterator: do {
     try expectEqual(Array(array), expectedProp_4)
 }
 
+Array_RandomAccessCollection: do {
+    let globalObject1 = getJSValue(this: .global, name: "globalObject1")
+    let globalObject1Ref = try expectObject(globalObject1)
+    let prop_4 = getJSValue(this: globalObject1Ref, name: "prop_4")
+    let array = try expectArray(prop_4)
+    let expectedProp_4: [JSValue] = [
+        .number(3), .number(4), .string("str_elm_1"), .number(5),
+    ]
+    try expectEqual([array[0], array[1], array[2], array[3]], expectedProp_4)
+}
+
 Value_Decoder: do {
     struct GlobalObject1: Codable {
         struct Prop1: Codable {

--- a/Sources/JavaScriptKit/JSArrayRef.swift
+++ b/Sources/JavaScriptKit/JSArrayRef.swift
@@ -14,8 +14,9 @@ public class JSArrayRef {
     }
 }
 
-extension JSArrayRef: Sequence {
+extension JSArrayRef: RandomAccessCollection {
     public typealias Element = JSValue
+    public typealias Index = Int
 
     public func makeIterator() -> Iterator {
         Iterator(ref: ref)
@@ -37,4 +38,12 @@ extension JSArrayRef: Sequence {
             return value.isNull ? nil : value
         }
     }
+
+    public subscript(position: Int) -> JSValue {
+        ref.get(position)
+    }
+
+    public var startIndex: Int { 0 }
+
+    public var endIndex: Int { ref.length.number.map(Int.init) ?? 0 }
 }

--- a/Sources/JavaScriptKit/JSArrayRef.swift
+++ b/Sources/JavaScriptKit/JSArrayRef.swift
@@ -16,7 +16,6 @@ public class JSArrayRef {
 
 extension JSArrayRef: RandomAccessCollection {
     public typealias Element = JSValue
-    public typealias Index = Int
 
     public func makeIterator() -> Iterator {
         Iterator(ref: ref)


### PR DESCRIPTION
This allows using `Int` subscripts on `JSArrayRef` instances and makes the rest of the functions available from the relevant extensions. This may shadow some JavaScript functions with the same names (I don't remember any off the top of my head), but I hope that the added convenience is worth it.

Also `.gitignore` is amended to include the `.build` directory created by `make test`.