### PR TITLE
Remove unused `Tests` directory

### DIFF
--- a/Tests/JavaScriptKitTests/JavaScriptKitTests.swift
+++ b/Tests/JavaScriptKitTests/JavaScriptKitTests.swift
@@ -1,4 +1,0 @@
-@testable import JavaScriptKit
-import XCTest
-
-final class JavaScriptKitTests: XCTestCase {}

--- a/Tests/JavaScriptKitTests/XCTestManifests.swift
+++ b/Tests/JavaScriptKitTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-    public func allTests() -> [XCTestCaseEntry] {
-        return [
-            testCase(swift_js_sysTests.allTests),
-        ]
-    }
-#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,7 +1,0 @@
-import XCTest
-
-import swift_js_sysTests
-
-var tests = [XCTestCaseEntry]()
-tests += swift_js_sysTests.allTests()
-XCTMain(tests)


### PR DESCRIPTION
Tests are executed without XCTest, and the current `Tests` directory didn't contain anything useful, thus it can be removed.