### PR TITLE
Add void-returning overload to `JSClosure.init`

### DIFF
--- a/Sources/JavaScriptKit/JSFunction.swift
+++ b/Sources/JavaScriptKit/JSFunction.swift
@@ -82,6 +82,13 @@ public class JSClosure: JSFunctionRef {
         id = objectRef
     }
 
+    convenience public init(_ body: @escaping ([JSValue]) -> ()) {
+        self.init { (arguments: [JSValue]) -> JSValue in
+            body(arguments)
+            return .undefined
+        }
+    }
+
     public func release() {
         Self.sharedFunctions[hostFuncRef] = nil
         isReleased = true


### PR DESCRIPTION
This is a great idea that @j-f1 posted in comments elsewhere: most of the time `JSClosure` instances return `.undefined`, so this is a common case that can be simplified with a corresponding overload.