### PR TITLE
Add JSError.stack, add Error conformance

### DIFF
--- a/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
+++ b/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
@@ -401,5 +401,5 @@ try test("Error") {
     try expectEqual(error.name, "Error")
     try expectEqual(error.message, message)
     try expectEqual(error.description, "Error: test error")
-    try expectEqual(error.stack.isEmpty, false)
+    try expectEqual(error.stack?.isEmpty, false)
 }

--- a/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
+++ b/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
@@ -401,4 +401,5 @@ try test("Error") {
     try expectEqual(error.name, "Error")
     try expectEqual(error.message, message)
     try expectEqual(error.description, "Error: test error")
+    try expectEqual(error.stack.isEmpty, false)
 }

--- a/Sources/JavaScriptKit/BasicObjects/JSError.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSError.swift
@@ -1,4 +1,4 @@
-public final class JSError {
+public final class JSError: Error {
     private let ref: JSObject
     private static let constructor = JSObject.global.Error.function!
 
@@ -12,6 +12,10 @@ public final class JSError {
 
     public var name: String {
         ref.name.string!
+    }
+
+    public var stack: String {
+        ref.stack.string!
     }
 }
 

--- a/Sources/JavaScriptKit/BasicObjects/JSError.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSError.swift
@@ -1,24 +1,36 @@
+/** A wrapper around the [JavaScript Error 
+class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) that
+exposes its properties in a type-safe way.
+*/
 public final class JSError: Error {
-    private let ref: JSObject
+    /// The underlying JavaScript `Error` object.
+    public let jsObject: JSObject
+
+    /// The constructor function used to create new `Error` objects.
     private static let constructor = JSObject.global.Error.function!
 
+    /// Creates a new instance of the JavaScript `Error` class with a given message.
     public init(message: String) {
-        ref = Self.constructor.new([message])
+        jsObject = Self.constructor.new([message])
     }
 
+    /// The error message of the underlying `Error` object.
     public var message: String {
-        ref.message.string!
+        jsObject.message.string!
     }
 
+    /// The name (usually corresponds to the name of the underlying class) of a given error.
     public var name: String {
-        ref.name.string!
+        jsObject.name.string!
     }
 
-    public var stack: String {
-        ref.stack.string!
+    /// The JavaScript call trace that led to the creation of this error object.
+    public var stack: String? {
+        jsObject.stack.string
     }
 }
 
 extension JSError: CustomStringConvertible {
-    public var description: String { ref.description }
+    /// The textual representation of this error.
+    public var description: String { jsObject.description }
 }


### PR DESCRIPTION
While the `stack` property is non-standard, it's [supported in all popular browser engines](https://caniuse.com/mdn-javascript_builtins_error_stack) and Node.js.

Unfortunately, because `stack` value will be different on every machine that executes it, I'm not sure how to write a good test for it, so it currently doesn't have any tests.

Also, `JSError` now conforms to `Error`. The main reasoning is that the `Publisher` protocol in Combine requires `Error` conformance on its `Failure` type. I think in the future it would make sense to make `JSPromise` compatible with Combine, so it would be great if one could propagate errors produced by `JSPromise` to other publishers/subscribers.

Again, `JSPromise` will be implemented in a separate PR.