### PR TITLE
Make JSValue ExpressibleByNilLiteral

### DIFF
--- a/Sources/JavaScriptKit/JSValue.swift
+++ b/Sources/JavaScriptKit/JSValue.swift
@@ -109,6 +109,12 @@ extension JSValue: ExpressibleByIntegerLiteral {
     }
 }
 
+extension JSValue: ExpressibleByNilLiteral {
+    public init(nilLiteral: ()) {
+        self = .null
+    }
+}
+
 public func getJSValue(this: JSObject, name: String) -> JSValue {
     var rawValue = RawJSValue()
     _get_prop(this.id, name, Int32(name.count),


### PR DESCRIPTION
I have `nil` produce `.null` now but should it produce `.undefined` instead maybe? This is the last thing needed to get DOMKit building without `AnyJSValueConvertible`.