### PR TITLE
Add a generic `JSPromise` implementation

### DIFF
--- a/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
+++ b/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
@@ -465,6 +465,26 @@ try test("Timer") {
     }
 }
 
+var timer: JSTimer?
+var promise: JSPromise<(), Never>?
+
+try test("Promise") {
+    let start = JSDate().valueOf()
+    let timeoutMilliseconds = 5.0
+
+    promise = JSPromise { resolve in
+        timer = JSTimer(millisecondsDelay: timeoutMilliseconds) {
+            resolve()
+        }
+    }
+
+    promise!.then {
+        // verify that at least `timeoutMilliseconds` passed since the `timer` 
+        // timer started
+        try! expectEqual(start + timeoutMilliseconds <= JSDate().valueOf(), true)
+    }
+}
+
 try test("Error") {
     let message = "test error"
     let error = JSError(message: message)

--- a/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
+++ b/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
@@ -479,8 +479,7 @@ try test("Promise") {
     }
 
     promise!.then {
-        // verify that at least `timeoutMilliseconds` passed since the `timer` 
-        // timer started
+        // verify that at least `timeoutMilliseconds` passed since the timer started
         try! expectEqual(start + timeoutMilliseconds <= JSDate().valueOf(), true)
     }
 }

--- a/Sources/JavaScriptKit/BasicObjects/JSArray.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSArray.swift
@@ -1,4 +1,4 @@
-/// A wrapper around [the JavaScript Array class](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Array)
+/// A wrapper around [the JavaScript Array class](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)
 /// that exposes its properties in a type-safe and Swifty way.
 public class JSArray {
     static let classObject = JSObject.global.Array.function!

--- a/Sources/JavaScriptKit/BasicObjects/JSError.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSError.swift
@@ -2,8 +2,8 @@
 class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) that
 exposes its properties in a type-safe way.
 */
-public final class JSError: Error {
-    /// The constructor function used to create new `Error` objects.
+public final class JSError: Error, JSValueConvertible {
+    /// The constructor function used to create new JavaScript `Error` objects.
     private static let constructor = JSObject.global.Error.function!
 
     /// The underlying JavaScript `Error` object.
@@ -27,6 +27,11 @@ public final class JSError: Error {
     /// The JavaScript call stack that led to the creation of this error object.
     public var stack: String? {
         jsObject.stack.string
+    }
+
+    /// Creates a new `JSValue` from this `JSError` instance.
+    public func jsValue() -> JSValue {
+        .object(jsObject)
     }
 }
 

--- a/Sources/JavaScriptKit/BasicObjects/JSPromise.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSPromise.swift
@@ -1,0 +1,132 @@
+/** A wrapper around [the JavaScript `Promise` class](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Promise)
+that exposes its functions in a type-safe and Swifty way. The `JSPromise` API is generic over both
+`Success` and `Failure` types, which improves compatibility with other statically-typed APIs such
+as Combine. If you don't know the exact type of your `Success` value, you should use `JSValue`, e.g.
+`JSPromise<JSValue, JSError>`. In the rare case, where you can't guarantee that the error thrown
+is of actual JavaScript `Error` type, you should use `JSPromise<JSValue, JSValue>`.
+*/
+public final class JSPromise<Success, Failure>: JSValueConvertible, JSValueConstructible
+where Success: JSValueConstructible, Failure: JSValueConstructible {
+    /// The underlying JavaScript `Promise` object.
+    public let jsObject: JSObject
+
+    private var callbacks = [JSClosure]()
+
+    /// The underlying JavaScript `Promise` object wrapped as `JSValue`.
+    public func jsValue() -> JSValue {
+        .object(jsObject)
+    }
+
+    /// This private initializer assumes that the passed object is a JavaScript `Promise`
+    private init(unsafe object: JSObject) {
+        self.jsObject = object
+    }
+
+    /** Creates a new `JSPromise` instance from a given JavaScript `Promise` object. If `jsObject`
+    is not an instance of JavaScript `Promise`, this initializer will return `nil`.
+    */
+    public init?(_ jsObject: JSObject) {
+        guard jsObject.isInstanceOf(JSObject.global.Promise.function!) else { return nil }
+        self.jsObject = jsObject
+    }
+
+    /** Creates a new `JSPromise` instance from a given JavaScript `Promise` object. If `value`
+    is not an object and is not an instance of JavaScript `Promise`, this function will 
+    return `nil`.
+    */
+    public static func construct(from value: JSValue) -> Self? {
+        guard case let .object(jsObject) = value else { return nil }
+        return Self.init(jsObject)
+    }
+
+    /** Schedules the `success` closure to be invoked on sucessful completion of `self`.
+    */
+    public func then(success: @escaping (Success) -> ()) {
+        let closure = JSClosure {
+            success(Success.construct(from: $0[0])!)
+        }
+        callbacks.append(closure)
+        jsObject.then.function!(closure)
+    }
+
+    /** Returns a new promise created from chaining the current `self` promise with the `success`
+    closure invoked on sucessful completion of `self`. The returned promise will have a new 
+    `Success` type equal to the return type of `success`.
+    */
+    public func then<ResultType: JSValueConvertible>(
+        success: @escaping (Success) -> ResultType
+    ) -> JSPromise<ResultType, Failure> {
+        let closure = JSClosure {
+            success(Success.construct(from: $0[0])!).jsValue()
+        }
+        callbacks.append(closure)
+        return .init(unsafe: jsObject.then.function!(closure).object!)
+    }
+
+    /** Returns a new promise created from chaining the current `self` promise with the `success`
+    closure invoked on sucessful completion of `self`. The returned promise will have a new type
+    equal to the return type of `success`.
+    */
+    public func then<ResultSuccess: JSValueConvertible, ResultFailure: JSValueConstructible>(
+        success: @escaping (Success) -> JSPromise<ResultSuccess, ResultFailure>
+    ) -> JSPromise<ResultSuccess, ResultFailure> {
+        let closure = JSClosure {
+            success(Success.construct(from: $0[0])!).jsValue()
+        }
+        callbacks.append(closure)
+        return .init(unsafe: jsObject.then.function!(closure).object!)
+    }
+
+    /** Schedules the `failure` closure to be invoked on rejected completion of `self`.
+    */
+    public func `catch`(failure: @escaping (Failure) -> ()) {
+        let closure = JSClosure {
+            failure(Failure.construct(from: $0[0])!)
+        }
+        callbacks.append(closure)
+        jsObject.then.function!(JSValue.undefined, closure)
+    }
+
+    /** Returns a new promise created from chaining the current `self` promise with the `failure`
+    closure invoked on rejected completion of `self`. The returned promise will have a new `Success`
+    type equal to the return type of the callback.
+    */
+    public func `catch`<ResultSuccess: JSValueConvertible>(
+        failure: @escaping (Failure) -> ResultSuccess
+    ) -> JSPromise<ResultSuccess, Never> {
+        let closure = JSClosure {
+            failure(Failure.construct(from: $0[0])!).jsValue()
+        }
+        callbacks.append(closure)
+        return .init(unsafe: jsObject.then.function!(JSValue.undefined, closure).object!)
+    }
+
+    /** Returns a new promise created from chaining the current `self` promise with the `failure`
+    closure invoked on rejected completion of `self`.  The returned promise will have a new type
+    equal to the return type of `success`.
+    */
+    public func `catch`<ResultSuccess: JSValueConvertible, ResultFailure: JSValueConstructible>(
+        failure: @escaping (Failure) -> JSPromise<ResultSuccess, ResultFailure>
+    ) -> JSPromise<ResultSuccess, ResultFailure> {
+        let closure = JSClosure {
+            failure(Failure.construct(from: $0[0])!).jsValue()
+        }
+        callbacks.append(closure)
+        return .init(unsafe: jsObject.then.function!(JSValue.undefined, closure).object!)
+    }
+
+    /** Schedules the `failure` closure to be invoked on either successful or rejected completion of 
+    `self`.
+    */
+    public func finally(successOrFailure: @escaping () -> ()) -> Self {
+        let closure = JSClosure { _ in
+            successOrFailure()
+        }
+        callbacks.append(closure)
+        return .init(unsafe: jsObject.finally.function!(closure).object!)
+    }
+
+    deinit {
+        callbacks.forEach { $0.release() }
+    }
+}

--- a/Sources/JavaScriptKit/BasicObjects/JSPromise.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSPromise.swift
@@ -89,7 +89,7 @@ extension JSPromise where Success == (), Failure == Never {
 }
 
 extension JSPromise where Failure: JSValueConvertible {
-    /** Creates a new `JSPromise` instance from a given `executor` closure. `resolver` takes 
+    /** Creates a new `JSPromise` instance from a given `resolver` closure. `resolver` takes 
     two closure that your code should call to either resolve or reject this `JSPromise` instance.
     */
     public convenience init(resolver: @escaping (@escaping (Result<Success, JSError>) -> ()) -> ()) {
@@ -114,7 +114,7 @@ extension JSPromise where Failure: JSValueConvertible {
 }
 
 extension JSPromise where Success: JSValueConvertible, Failure: JSError {
-    /** Creates a new `JSPromise` instance from a given `executor` closure. `executor` takes 
+    /** Creates a new `JSPromise` instance from a given `resolver` closure. `resolver` takes 
     a closure that your code should call to either resolve or reject this `JSPromise` instance.
     */
     public convenience init(resolver: @escaping (@escaping (Result<Success, JSError>) -> ()) -> ()) {

--- a/Sources/JavaScriptKit/BasicObjects/JSPromise.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSPromise.swift
@@ -4,6 +4,10 @@ that exposes its functions in a type-safe and Swifty way. The `JSPromise` API is
 as Combine. If you don't know the exact type of your `Success` value, you should use `JSValue`, e.g.
 `JSPromise<JSValue, JSError>`. In the rare case, where you can't guarantee that the error thrown
 is of actual JavaScript `Error` type, you should use `JSPromise<JSValue, JSValue>`.
+
+This doesn't 100% match the JavaScript API, as `then` overload with two callbacks is not available.
+It's impossible to unify success and failure types from both callbacks in a single returned promise
+without type erasure. You should chain `then` and `catch` in those cases to avoid type erasure.
 */
 public final class JSPromise<Success, Failure>: JSValueConvertible, JSValueConstructible
 where Success: JSValueConstructible, Failure: JSValueConstructible {

--- a/Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift
@@ -8,7 +8,7 @@ public protocol TypedArrayElement: JSValueConvertible, JSValueConstructible {
     static var typedArrayClass: JSFunction { get }
 }
 
-/// A wrapper around [the JavaScript TypedArray class](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/TypedArray)
+/// A wrapper around [the JavaScript TypedArray class](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray)
 /// that exposes its properties in a type-safe and Swifty way.
 public class JSTypedArray<Element>: JSValueConvertible, ExpressibleByArrayLiteral where Element: TypedArrayElement {
     let ref: JSObject

--- a/Sources/JavaScriptKit/JSValueConstructible.swift
+++ b/Sources/JavaScriptKit/JSValueConstructible.swift
@@ -91,9 +91,3 @@ extension UInt64: JSValueConstructible {
         value.number.map(Self.init)
     }
 }
-
-extension Never: JSValueConstructible {
-    public static func construct(from value: JSValue) -> Never? {
-        fatalError()
-    }
-}

--- a/Sources/JavaScriptKit/JSValueConstructible.swift
+++ b/Sources/JavaScriptKit/JSValueConstructible.swift
@@ -91,3 +91,9 @@ extension UInt64: JSValueConstructible {
         value.number.map(Self.init)
     }
 }
+
+extension Never: JSValueConstructible {
+    public static func construct(from value: JSValue) -> Never? {
+        fatalError()
+    }
+}


### PR DESCRIPTION
This provides three overloads each for `then` and `catch`, and I'm not sure if that's good for the type-checker performance and usability. I was thinking of naming the promise-returning callback version `flatMap`, but ultimately decided against it.

`then` overload with two callbacks is not available, because it's impossible to unify success and failure types from both callbacks in a single returned promise without type erasure. I think users should just chain `then` and `catch` in those cases so that type erasure is avoided.