### PR TITLE
Use upstream `swift-doc` with prebuilt Docker image

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,7 +2,7 @@ name: Documentation
 
 on:
   push:
-#     branches: [master]
+     branches: [master]
 
 jobs:
   swift-doc:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,7 +2,7 @@ name: Documentation
 
 on:
   push:
-     branches: [master]
+    branches: [master]
 
 jobs:
   swift-doc:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,7 +2,7 @@ name: Documentation
 
 on:
   push:
-    branches: [master]
+#     branches: [master]
 
 jobs:
   swift-doc:
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Generate Documentation
-        uses: MaxDesiatov/swift-doc@prebuilt-image
+        uses: SwiftDocOrg/swift-doc@master
         with:
           inputs: "Sources"
           module-name: JavaScriptKit


### PR DESCRIPTION
Thanks to https://github.com/SwiftDocOrg/swift-doc/issues/111 we probably no longer need to use a forked version of `swift-doc`.