### PR TITLE
Add missing .npmignore, bump version to 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.7.2 (28 September 2020)
+
+This is a bugfix release that resolves an issue with the JavaScript runtime being unavailable when installed via NPM.
+
 # 0.7.1 (27 September 2020)
 
 This is a bugfix release that resolves an issue with the JavaScript runtime being unavailable when installed via NPM.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "javascript-kit-swift",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javascript-kit-swift",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A runtime library of JavaScriptKit which is Swift framework to interact with JavaScript through WebAssembly.",
   "main": "Runtime/lib/index.js",
   "files": [


### PR DESCRIPTION
In 0.7.1 the runtime files are still not available through npm. [The reason was this](https://docs.npmjs.com/files/package.json#files):

>If there is a `.gitignore` file, and `.npmignore` is missing, `.gitignore`’s contents will be used instead.

The `Runtime` directory had `.gitignore` that mentioned the `lib` subdirectory with transpiled files. This made sense, but absence of `.npmignore` excluded these files from uploading.