### PR TITLE
Make `JSError` conform to `JSBridgedClass`

### DIFF
--- a/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
+++ b/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
@@ -487,9 +487,12 @@ try test("Promise") {
 
 try test("Error") {
     let message = "test error"
+    let expectedDescription = "Error: test error"
     let error = JSError(message: message)
     try expectEqual(error.name, "Error")
     try expectEqual(error.message, message)
-    try expectEqual(error.description, "Error: test error")
+    try expectEqual(error.description, expectedDescription)
     try expectEqual(error.stack?.isEmpty, false)
+    try expectEqual(JSError(from: .string("error"))?.description, nil)
+    try expectEqual(JSError(from: .object(error.jsObject))?.description, expectedDescription)
 }

--- a/Sources/JavaScriptKit/BasicObjects/JSError.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSError.swift
@@ -43,3 +43,10 @@ extension JSError: CustomStringConvertible {
     /// The textual representation of this error.
     public var description: String { jsObject.description }
 }
+
+extension JSError: JSValueConstructible {
+  public static func construct(from value: JSValue) -> JSError? {
+    guard let object = value.object else { return nil }
+    return JSError(unsafelyWrapping: object)
+  }
+}

--- a/Sources/JavaScriptKit/BasicObjects/JSError.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSError.swift
@@ -2,7 +2,7 @@
 class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) that
 exposes its properties in a type-safe way.
 */
-public final class JSError: Error, JSValueConvertible {
+public final class JSError: Error, JSBridgedClass {
     /// The constructor function used to create new JavaScript `Error` objects.
     public static let constructor = JSObject.global.Error.function!
 
@@ -42,11 +42,4 @@ public final class JSError: Error, JSValueConvertible {
 extension JSError: CustomStringConvertible {
     /// The textual representation of this error.
     public var description: String { jsObject.description }
-}
-
-extension JSError: JSValueConstructible {
-  public static func construct(from value: JSValue) -> JSError? {
-    guard let object = value.object else { return nil }
-    return JSError(unsafelyWrapping: object)
-  }
 }


### PR DESCRIPTION
The lack of this conformance makes it impossible to attach `catch` callbacks to `JSPromise` when `Failure: JSError`, as `catch` methods have `Failure: JSValueConstructible` constraints.