### PR TITLE
Add Asyncify support

### DIFF
--- a/Sources/JavaScriptKit/PauseExecution.swift
+++ b/Sources/JavaScriptKit/PauseExecution.swift
@@ -8,6 +8,8 @@ public func pauseExecution(milliseconds: Int32) {
     _sleep(milliseconds)
 }
 
+
+extension JSPromise where Success == JSValue, Failure == JSError {
     /// Unwind Wasm module execution stack and rewind it after promise resolves,
     /// allowing JavaScript events to continue to be processed in the meantime.
     /// - Parameters:

--- a/Sources/JavaScriptKit/PauseExecution.swift
+++ b/Sources/JavaScriptKit/PauseExecution.swift
@@ -1,0 +1,9 @@
+import _CJavaScriptKit
+
+/// Unwind Wasm module execution stack and rewind it after specified milliseconds,
+/// allowing JavaScript events to continue to be processed.
+/// **Important**: Wasm module must be [asyncified](https://emscripten.org/docs/porting/asyncify.html),
+/// otherwise JavaScriptKit's runtime will throw an exception.
+public func pauseExecution(milliseconds: Int32) {
+    _sleep(milliseconds)
+}

--- a/Sources/JavaScriptKit/PauseExecution.swift
+++ b/Sources/JavaScriptKit/PauseExecution.swift
@@ -7,3 +7,34 @@ import _CJavaScriptKit
 public func pauseExecution(milliseconds: Int32) {
     _sleep(milliseconds)
 }
+
+    /// Unwind Wasm module execution stack and rewind it after promise resolves,
+    /// allowing JavaScript events to continue to be processed in the meantime.
+    /// - Parameters:
+    ///     - timeout: If provided, method will return a failure if promise cannot resolve
+    ///      before timeout is reached.
+    ///
+    /// **Important**: Wasm module must be [asyncified](https://emscripten.org/docs/porting/asyncify.html),
+    /// otherwise JavaScriptKit's runtime will throw an exception.
+    public func syncAwait(timeout: Int32? = nil) -> Result<Success, Failure> {
+        var kindAndFlags = JavaScriptValueKindAndFlags()
+        var payload1 = JavaScriptPayload1()
+        var payload2 = JavaScriptPayload2()
+        
+        if let timout = timeout {
+            _syncAwaitWithTimout(jsObject.id, timout, &kindAndFlags, &payload1, &payload2)
+        } else {
+            _syncAwait(jsObject.id, &kindAndFlags, &payload1, &payload2)
+        }
+        let result = RawJSValue(kind: kindAndFlags.kind, payload1: payload1, payload2: payload2).jsValue()
+        if kindAndFlags.isException {
+            if let error = JSError(from: result) {
+                return .failure(error)
+            } else {
+                return .failure(JSError(message: "Could not build proper JSError from result \(result)"))
+            }
+        } else {
+            return .success(result)
+        }
+    }
+}

--- a/Sources/JavaScriptKit/XcodeSupport.swift
+++ b/Sources/JavaScriptKit/XcodeSupport.swift
@@ -89,5 +89,6 @@ import _CJavaScriptKit
         _: Int32,
         _: UnsafeMutablePointer<JavaScriptObjectRef>!
     ) { fatalError() }
+    func _sleep(_ ms: Int32) { fatalError() }
 
 #endif

--- a/Sources/JavaScriptKit/XcodeSupport.swift
+++ b/Sources/JavaScriptKit/XcodeSupport.swift
@@ -89,6 +89,19 @@ import _CJavaScriptKit
         _: Int32,
         _: UnsafeMutablePointer<JavaScriptObjectRef>!
     ) { fatalError() }
-    func _sleep(_ ms: Int32) { fatalError() }
+    func _sleep(_: Int32) { fatalError() }
+    func _syncAwait(
+        _: JavaScriptObjectRef,
+        _: UnsafeMutablePointer<JavaScriptValueKindAndFlags>!,
+        _: UnsafeMutablePointer<JavaScriptPayload1>!,
+        _: UnsafeMutablePointer<JavaScriptPayload2>!
+    ) { fatalError() }
+    func _syncAwaitWithTimout(
+        _: JavaScriptObjectRef,
+        _: Int32,
+        _: UnsafeMutablePointer<JavaScriptValueKindAndFlags>!,
+        _: UnsafeMutablePointer<JavaScriptPayload1>!,
+        _: UnsafeMutablePointer<JavaScriptPayload2>!
+    ) { fatalError() }
 
 #endif

--- a/Sources/_CJavaScriptKit/include/_CJavaScriptKit.h
+++ b/Sources/_CJavaScriptKit/include/_CJavaScriptKit.h
@@ -258,6 +258,16 @@ extern void _create_typed_array(const JavaScriptObjectRef constructor,
                                 const void *elements_ptr, const int length,
                                 JavaScriptObjectRef *result_obj);
 
+/// Unwind Wasm module execution stack and rewind it after specified milliseconds,
+/// allowing JavaScript events to continue to be processed.
+/// **Important**: Wasm module must be [asyncified](https://emscripten.org/docs/porting/asyncify.html),
+/// otherwise JavaScriptKit's runtime will throw an exception.
+///
+/// @param ms Length of time in milliseconds to pause execution for.
+__attribute__((__import_module__("javascript_kit"),
+               __import_name__("swjs_sleep")))
+extern void _sleep(const int ms);
+
 #endif
 
 #endif /* _CJavaScriptKit_h */

--- a/Sources/_CJavaScriptKit/include/_CJavaScriptKit.h
+++ b/Sources/_CJavaScriptKit/include/_CJavaScriptKit.h
@@ -268,6 +268,39 @@ __attribute__((__import_module__("javascript_kit"),
                __import_name__("swjs_sleep")))
 extern void _sleep(const int ms);
 
+/// Unwind Wasm module execution stack and rewind it after promise is fulfilled.
+/// **Important**: Wasm module must be [asyncified](https://emscripten.org/docs/porting/asyncify.html),
+/// otherwise JavaScriptKit's runtime will throw an exception.
+///
+/// @param promise target JavaScript promise.
+/// @param result_kind A result pointer of JavaScript value kind of returned result or thrown exception.
+/// @param result_payload1 A result pointer of first payload of JavaScript value of returned result or thrown exception.
+/// @param result_payload2 A result pointer of second payload of JavaScript value of returned result or thrown exception.
+__attribute__((__import_module__("javascript_kit"),
+               __import_name__("swjs_sync_await")))
+extern void _syncAwait(const JavaScriptObjectRef promise,
+                       JavaScriptValueKindAndFlags *result_kind,
+                       JavaScriptPayload1 *result_payload1,
+                       JavaScriptPayload2 *result_payload2);
+
+/// Unwind Wasm module execution stack and rewind it after promise is fulfilled or timeout is reached.
+/// **Important**: Wasm module must be [asyncified](https://emscripten.org/docs/porting/asyncify.html),
+/// otherwise JavaScriptKit's runtime will throw an exception.
+///
+/// @param promise target JavaScript promise.
+/// @param ms Length of timeout in milliseconds.
+/// @param result_kind A result pointer of JavaScript value kind of returned result or thrown exception.
+/// @param result_payload1 A result pointer of first payload of JavaScript value of returned result or thrown exception.
+/// @param result_payload2 A result pointer of second payload of JavaScript value of returned result or thrown exception.
+__attribute__((__import_module__("javascript_kit"),
+               __import_name__("swjs_sync_await_with_timeout")))
+extern void _syncAwaitWithTimout(const JavaScriptObjectRef promise,
+                                 const int ms,
+                                 JavaScriptValueKindAndFlags *result_kind,
+                                 JavaScriptPayload1 *result_payload1,
+                                 JavaScriptPayload2 *result_payload2);
+
+
 #endif
 
 #endif /* _CJavaScriptKit_h */


### PR DESCRIPTION
## What this adds
Calls out to modules with `wasm-opt`'s `--asyncify` pass to unwind and rewind the module's call stack when we want to put Swift execution to sleep while allowing incoming events to be handled by JavaScript.

## Further Reading
[Alon Zakai's Blog](https://coursehunters.online/t/educative-io-design-gurus-grokking-the-system-design-interview-part-1/579/1)
[Alon Zakai's Talk](https://www.youtube.com/watch?v=qQOP6jqZqf8)
[Binaryen Docs](https://emscripten.org/docs/porting/asyncify.html)
[Experimental JS wrapper from Google](https://github.com/GoogleChromeLabs/asyncify)

## Concerns
- This adds a bit of complexity on the JS runtime side, especially the need to provide a 'restart' method for re-entering module execution. Should not affect existing usage as all additions are optional.
- At Swift build time, there is no way of knowing if module will be asyncified so no way to block usage of new methods. The Asyncify pass is extremely slow as well, so not a good candidate to add e.g. to carton's build process.