### PR TITLE
Bump version to 0.9.0, update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 0.9.0 (27 November 2020)
+
+This release introduces support for catching `JSError` instances in Swift from throwing JavaScript
+functions. This is possible thanks to the new `JSThrowingFunction` and `JSThrowingObject` classes.
+The former can only be called with `try`, while the latter will expose all of its member functions
+as throwing. Use the new `throws` property on `JSFunction` to convert it to `JSThrowingFunction`,
+and the new `throwing` property on `JSObject` to convert it to `JSThrowingObject`.
+
+**Closed issues:**
+
+- Support JS errors ([#37](https://github.com/swiftwasm/JavaScriptKit/issues/37))
+
+**Merged pull requests:**
+
+- Update toolchain version swift-wasm-5.3.0-RELEASE ([#108](https://github.com/swiftwasm/JavaScriptKit/pull/108)) via [@kateinoigakukun](https://github.com/kateinoigakukun)
+- Update ci trigger condition ([#104](https://github.com/swiftwasm/JavaScriptKit/pull/104)) via [@kateinoigakukun](https://github.com/kateinoigakukun)
+- Fix branch and triple in `compatibility.yml` ([#105](https://github.com/swiftwasm/JavaScriptKit/pull/105)) via [@MaxDesiatov](https://github.com/MaxDesiatov)
+- Check source code compatibility ([#103](https://github.com/swiftwasm/JavaScriptKit/pull/103)) via [@kateinoigakukun](https://github.com/kateinoigakukun)
+- JS Exception Support ([#102](https://github.com/swiftwasm/JavaScriptKit/pull/102)) via [@kateinoigakukun](https://github.com/kateinoigakukun)
+- Mention `carton` Docker image and refine wording in `README.md` ([#101](https://github.com/swiftwasm/JavaScriptKit/pull/101)) via [@MaxDesiatov](https://github.com/MaxDesiatov)
+
 # 0.8.0 (21 October 2020)
 
 This release introduces a few enhancements and deprecations. Namely, `JSValueConstructible`

--- a/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
+++ b/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
@@ -562,7 +562,7 @@ try test("Exception") {
     try expectEqual(error4 is JSValue, true)
     let errorObject2 = JSError(from: error4 as! JSValue)
     try expectNotNil(errorObject2)
-    
+
     // MARK: Throwing constructor call
     let Animal = JSObject.global.Animal.function!
     _ = try Animal.throws.new("Tama", 3, true)

--- a/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
@@ -76,7 +76,7 @@ public class JSObject: Equatable {
         get { getJSValue(this: self, index: Int32(index)) }
         set { setJSValue(this: self, index: Int32(index), value: newValue) }
     }
-    
+
     /// A modifier to call methods as throwing methods capturing `this`
     ///
     ///

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,31 @@
 {
   "name": "javascript-kit-swift",
-  "version": "0.8.0",
-  "lockfileVersion": 1,
+  "version": "0.9.0",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "javascript-kit-swift",
+      "version": "0.9.0",
+      "license": "MIT",
+      "devDependencies": {
+        "prettier": "2.1.2",
+        "typescript": "^4.0.2"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
+      "dev": true
+    },
+    "node_modules/typescript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
+      "dev": true
+    }
+  },
   "dependencies": {
     "prettier": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javascript-kit-swift",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A runtime library of JavaScriptKit which is Swift framework to interact with JavaScript through WebAssembly.",
   "main": "Runtime/lib/index.js",
   "files": [


### PR DESCRIPTION
I'm preparing a new `carton` release for SwiftWasm 5.3.1, would be great to update its bundled runtime bits and include support for throwing functions from the newly tagged 0.9.0.