### PR TITLE
Fix recursion in TypedArray initializer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,6 @@ jobs:
       matrix:
         os: [macos-10.15, macos-11, ubuntu-18.04, ubuntu-20.04]
         toolchain:
-          - wasm-5.3.1-RELEASE
           - wasm-5.4.0-RELEASE
           - wasm-5.5-SNAPSHOT-2021-10-02-a
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,7 @@ jobs:
       matrix:
         os: [macos-10.15, macos-11, ubuntu-18.04, ubuntu-20.04]
         toolchain:
-          - wasm-5.4.0-RELEASE
-          - wasm-5.5-SNAPSHOT-2021-10-02-a
+          - wasm-5.5-SNAPSHOT-2021-11-20-a
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/IntegrationTests/TestSuites/Sources/ConcurrencyTests/main.swift
+++ b/IntegrationTests/TestSuites/Sources/ConcurrencyTests/main.swift
@@ -60,7 +60,7 @@ func entrypoint() async throws {
 
     try await asyncTest("Task.sleep(_:)") {
         let start = time(nil)
-        await Task.sleep(2_000_000_000)
+        try await Task.sleep(nanoseconds: 2_000_000_000)
         let diff = difftime(time(nil), start);
         try expectEqual(diff >= 2, true)
     }
@@ -100,9 +100,9 @@ func entrypoint() async throws {
     // FIXME(katei): Somehow it doesn't work due to a mysterious unreachable inst
     // at the end of thunk.
     // This issue is not only on JS host environment, but also on standalone coop executor.
-    // try await asyncTest("Task.sleep(nanoseconds:)") {
-    //     try await Task.sleep(nanoseconds: 1_000_000_000)
-    // }
+    try await asyncTest("Task.sleep(nanoseconds:)") {
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+    }
 }
 
 

--- a/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
+++ b/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
@@ -441,6 +441,10 @@ try test("TypedArray") {
     let typedArray = JSTypedArray(numbers)
     try expectEqual(typedArray[12], 12)
 
+    let numbersSet = Set(0 ... 255)
+    let typedArrayFromSet = JSTypedArray(numbersSet)
+    try expectEqual(typedArrayFromSet.jsObject.length, 12)
+
     try checkArray([0, .max, 127, 1] as [UInt8])
     try checkArray([0, 1, .max, .min, -1] as [Int8])
 

--- a/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
+++ b/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
@@ -443,7 +443,7 @@ try test("TypedArray") {
 
     let numbersSet = Set(0 ... 255)
     let typedArrayFromSet = JSTypedArray(numbersSet)
-    try expectEqual(typedArrayFromSet.jsObject.length, 12)
+    try expectEqual(typedArrayFromSet.jsObject.length, 256)
 
     try checkArray([0, .max, 127, 1] as [UInt8])
     try checkArray([0, 1, .max, .min, -1] as [Int8])

--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -154,7 +154,7 @@ export class SwiftRuntime {
         const exports = (this.instance
             .exports as any) as SwiftRuntimeExportedFunctions;
         if (exports.swjs_library_version() != this.version) {
-            throw new Error("The versions of JavaScriptKit are incompatible.");
+            throw new Error(`The versions of JavaScriptKit are incompatible. ${exports.swjs_library_version()} != ${this.version}`);
         }
     }
     get closureHeap(): SwiftClosureHeap | null {

--- a/Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift
@@ -50,7 +50,7 @@ public class JSTypedArray<Element>: JSBridgedClass, ExpressibleByArrayLiteral wh
         }
         self.init(unsafelyWrapping: JSObject(id: resultObj))
     }
-    
+
     /// Convenience initializer for `Sequence`.
     public convenience init<S: Sequence>(_ sequence: S) where S.Element == Element {
         self.init(Array(sequence))

--- a/Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift
@@ -52,8 +52,8 @@ public class JSTypedArray<Element>: JSBridgedClass, ExpressibleByArrayLiteral wh
     }
     
     /// Convenience initializer for `Sequence`.
-    public convenience init<S: Sequence>(_ sequence: S) {
-        self.init(sequence.map({ $0 }))
+    public convenience init<S: Sequence>(_ sequence: S) where S.Element == Element {
+        self.init(Array(sequence))
     }
 }
 


### PR DESCRIPTION
The original unconstrained version would cause infinite recursion.