### PR TITLE
Remove macOS Monterey requirement from `Package.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,12 +4,6 @@ import PackageDescription
 
 let package = Package(
     name: "JavaScriptKit",
-    platforms: [
-        // This package doesn't work on macOS host, but should be able to be built for it
-        // for developing on Xcode. This minimum version requirement is to prevent availability
-        // errors for Concurrency API, whose runtime support is shipped from macOS 12.0
-        .macOS("12.0")
-    ],
     products: [
         .library(name: "JavaScriptKit", targets: ["JavaScriptKit"]),
         .library(name: "JavaScriptEventLoop", targets: ["JavaScriptEventLoop"]),


### PR DESCRIPTION
This currently prevents Tokamak from being built on macOS 11 or earlier macOS versions. I think the original concern is no longer an issue, where back-deployment with Xcode 13.2 to old macOS versions will become available really soon. In fact, beta versions of Xcode 13.2 are already available on GitHub Actions if we need to test with those.