### PR TITLE
proposal: mechanism for using alternate backends

### DIFF
--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -151,8 +151,8 @@ export class SwiftRuntime {
 
     setInstance(instance: WebAssembly.Instance) {
         this.instance = instance;
-        const exports = (this.instance
-            .exports as any) as SwiftRuntimeExportedFunctions;
+        const exports = this.instance
+            .exports as any as SwiftRuntimeExportedFunctions;
         if (exports.swjs_library_version() != this.version) {
             throw new Error(
                 `The versions of JavaScriptKit are incompatible. ${exports.swjs_library_version()} != ${
@@ -166,8 +166,8 @@ export class SwiftRuntime {
         if (!this.instance)
             throw new Error("WebAssembly instance is not set yet");
 
-        const exports = (this.instance
-            .exports as any) as SwiftRuntimeExportedFunctions;
+        const exports = this.instance
+            .exports as any as SwiftRuntimeExportedFunctions;
         const features = exports.swjs_library_features();
         const librarySupportsWeakRef =
             (features & LibraryFeatures.WeakRefs) != 0;
@@ -194,8 +194,8 @@ export class SwiftRuntime {
         const callHostFunction = (host_func_id: number, args: any[]) => {
             if (!this.instance)
                 throw new Error("WebAssembly instance is not set yet");
-            const exports = (this.instance
-                .exports as any) as SwiftRuntimeExportedFunctions;
+            const exports = this.instance
+                .exports as any as SwiftRuntimeExportedFunctions;
             const argc = args.length;
             const argv = exports.swjs_prepare_host_function_call(argc);
             for (let index = 0; index < args.length; index++) {
@@ -570,9 +570,8 @@ export class SwiftRuntime {
                 elementsPtr: pointer,
                 length: number
             ) => {
-                const ArrayType: TypedArray = this.heap.referenceHeap(
-                    constructor_ref
-                );
+                const ArrayType: TypedArray =
+                    this.heap.referenceHeap(constructor_ref);
                 const array = new ArrayType(
                     memory().buffer,
                     elementsPtr,

--- a/Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift
@@ -44,8 +44,7 @@ public class JSTypedArray<Element>: JSBridgedClass, ExpressibleByArrayLiteral wh
     ///
     /// - Parameter array: The array that will be copied to create a new instance of TypedArray
     public convenience init(_ array: [Element], using bridge: JSBridge.Type = CJSBridge.self) {
-        let jsArrayRef = array.withUnsafeBufferPointer(bridge.createTypedArray(buffer:))
-        self.init(unsafelyWrapping: JSObject(id: jsArrayRef, using: bridge))
+        self.init(unsafelyWrapping: JSObject(id: bridge.createTypedArray(copying: array), using: bridge))
     }
 
     /// Convenience initializer for `Sequence`.

--- a/Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift
@@ -44,7 +44,7 @@ public class JSTypedArray<Element>: JSBridgedClass, ExpressibleByArrayLiteral wh
     ///
     /// - Parameter array: The array that will be copied to create a new instance of TypedArray
     public convenience init(_ array: [Element], using bridge: JSBridge.Type = CJSBridge.self) {
-        self.init(unsafelyWrapping: JSObject(id: bridge.createTypedArray(copying: array), using: bridge))
+        self.init(unsafelyWrapping: JSObject(id: bridge.createTypedArray(copying: array, as: Element.typedArrayClass.id), using: bridge))
     }
 
     /// Convenience initializer for `Sequence`.

--- a/Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift
@@ -43,16 +43,14 @@ public class JSTypedArray<Element>: JSBridgedClass, ExpressibleByArrayLiteral wh
     /// Initialize a new instance of TypedArray in JavaScript environment with given elements.
     ///
     /// - Parameter array: The array that will be copied to create a new instance of TypedArray
-    public convenience init(_ array: [Element]) {
-        let jsArrayRef = array.withUnsafeBufferPointer { ptr in
-            _create_typed_array(Element.typedArrayClass.id, ptr.baseAddress!, Int32(array.count))
-        }
-        self.init(unsafelyWrapping: JSObject(id: jsArrayRef))
+    public convenience init(_ array: [Element], using bridge: JSBridge.Type = CJSBridge.self) {
+        let jsArrayRef = array.withUnsafeBufferPointer(bridge.createTypedArray(buffer:))
+        self.init(unsafelyWrapping: JSObject(id: jsArrayRef, using: bridge))
     }
 
     /// Convenience initializer for `Sequence`.
-    public convenience init<S: Sequence>(_ sequence: S) where S.Element == Element {
-        self.init(Array(sequence))
+    public convenience init<S: Sequence>(_ sequence: S, using bridge: JSBridge.Type = CJSBridge.self) where S.Element == Element {
+        self.init(Array(sequence), using: bridge)
     }
 }
 

--- a/Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift
@@ -44,6 +44,7 @@ public class JSTypedArray<Element>: JSBridgedClass, ExpressibleByArrayLiteral wh
     ///
     /// - Parameter array: The array that will be copied to create a new instance of TypedArray
     public convenience init(_ array: [Element], using bridge: JSBridge.Type = CJSBridge.self) {
+        // TODO: allow retrieving the appropriate typed array class for a non-default bridge
         self.init(unsafelyWrapping: JSObject(id: bridge.createTypedArray(copying: array, as: Element.typedArrayClass.id), using: bridge))
     }
 

--- a/Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift
@@ -43,14 +43,15 @@ public class JSTypedArray<Element>: JSBridgedClass, ExpressibleByArrayLiteral wh
     /// Initialize a new instance of TypedArray in JavaScript environment with given elements.
     ///
     /// - Parameter array: The array that will be copied to create a new instance of TypedArray
-    public convenience init(_ array: [Element], using bridge: JSBridge.Type = CJSBridge.self) {
-        // TODO: allow retrieving the appropriate typed array class for a non-default bridge
-        self.init(unsafelyWrapping: JSObject(id: bridge.createTypedArray(copying: array, as: Element.typedArrayClass.id), using: bridge))
+    // TODO: allow using a non-default bridge
+    public convenience init(_ array: [Element]) {
+        let cls = Element.typedArrayClass
+        self.init(unsafelyWrapping: JSObject(id: cls.bridge.createTypedArray(copying: array, as: cls.id), using: cls.bridge))
     }
 
     /// Convenience initializer for `Sequence`.
-    public convenience init<S: Sequence>(_ sequence: S, using bridge: JSBridge.Type = CJSBridge.self) where S.Element == Element {
-        self.init(Array(sequence), using: bridge)
+    public convenience init<S: Sequence>(_ sequence: S) where S.Element == Element {
+        self.init(Array(sequence))
     }
 }
 

--- a/Sources/JavaScriptKit/ConvertibleToJSValue.swift
+++ b/Sources/JavaScriptKit/ConvertibleToJSValue.swift
@@ -173,10 +173,7 @@ extension Array: ConstructibleFromJSValue where Element: ConstructibleFromJSValu
     }
 }
 
-extension RawJSValue: ConvertibleToJSValue {
-    public func jsValue() -> JSValue {
-        jsValue(using: CJSBridge.self)
-    }
+extension RawJSValue {
     public func jsValue(using bridge: JSBridge.Type) -> JSValue {
         switch kind {
         case .invalid:

--- a/Sources/JavaScriptKit/ConvertibleToJSValue.swift
+++ b/Sources/JavaScriptKit/ConvertibleToJSValue.swift
@@ -174,7 +174,7 @@ extension Array: ConstructibleFromJSValue where Element: ConstructibleFromJSValu
 }
 
 extension RawJSValue {
-    public func jsValue(using bridge: JSBridge.Type) -> JSValue {
+    func jsValue(using bridge: JSBridge.Type) -> JSValue {
         switch kind {
         case .invalid:
             fatalError()

--- a/Sources/JavaScriptKit/FundamentalObjects/CJSBridge.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/CJSBridge.swift
@@ -85,9 +85,9 @@ public struct CJSBridge: JSBridge {
         _instanceof(obj, constructor)
     }
 
-    public static func createTypedArray<Element: TypedArrayElement>(copying array: [Element]) -> JSObject.Ref {
+    public static func createTypedArray<Element: TypedArrayElement>(copying array: [Element], as class: JSObject.Ref) -> JSObject.Ref {
         array.withUnsafeBufferPointer { buffer in
-            _create_typed_array(Element.typedArrayClass.id, buffer.baseAddress!, Int32(buffer.count))
+            _create_typed_array(`class`, buffer.baseAddress!, Int32(buffer.count))
         }
     }
 

--- a/Sources/JavaScriptKit/FundamentalObjects/CJSBridge.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/CJSBridge.swift
@@ -1,4 +1,4 @@
-public struct CJSBridge: JSBridge {
+public enum CJSBridge: JSBridge {
     // MARK: Objects
     public static func set(on object: JSObject.Ref, property: JSObject.Ref, to value: RawJSValue) {
         _set_prop(object, property, value.kind, value.payload1, value.payload2)

--- a/Sources/JavaScriptKit/FundamentalObjects/CJSBridge.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/CJSBridge.swift
@@ -40,7 +40,7 @@ public struct CJSBridge: JSBridge {
     // MARK: Functions
     public static func call(function: JSObject.Ref, args: [RawJSValue]) -> JSThrowingCallResult<RawJSValue> {
         args.withUnsafeBufferPointer { args in
-            var kindAndFlags = RawJSValue.KindWithFlags()
+            var kindAndFlags = RawJSValue.KindAndFlags()
             let value = withRawJSValue { jsValue in
                 _call_function(function, args.baseAddress!, Int32(args.count), &kindAndFlags, &jsValue.payload1, &jsValue.payload2)
                 jsValue.kind = kindAndFlags.kind
@@ -51,7 +51,7 @@ public struct CJSBridge: JSBridge {
 
     public static func call(function: JSObject.Ref, this: JSObject.Ref, args: [RawJSValue]) -> JSThrowingCallResult<RawJSValue> {
         args.withUnsafeBufferPointer { args in
-            var kindAndFlags = RawJSValue.KindWithFlags()
+            var kindAndFlags = RawJSValue.KindAndFlags()
             let value = withRawJSValue { jsValue in
                 _call_function_with_this(function, this, args.baseAddress!, Int32(args.count), &kindAndFlags, &jsValue.payload1, &jsValue.payload2)
                 jsValue.kind = kindAndFlags.kind
@@ -68,7 +68,7 @@ public struct CJSBridge: JSBridge {
 
     public static func throwingNew(class: JSObject.Ref, args: [RawJSValue]) -> JSThrowingCallResult<JSObject.Ref> {
         args.withUnsafeBufferPointer { args in
-            var kindAndFlags = RawJSValue.KindWithFlags()
+            var kindAndFlags = RawJSValue.KindAndFlags()
             var exception = RawJSValue()
             let objectRef = _call_throwing_new(`class`, args.baseAddress!, Int32(args.count), &kindAndFlags, &exception.payload1, &exception.payload2)
             exception.kind = kindAndFlags.kind

--- a/Sources/JavaScriptKit/FundamentalObjects/CJSBridge.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/CJSBridge.swift
@@ -98,4 +98,5 @@ public struct CJSBridge: JSBridge {
         return rawValue
     }
 
+    public static let globalRef: JSObject.Ref = 0
 }

--- a/Sources/JavaScriptKit/FundamentalObjects/CJSBridge.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/CJSBridge.swift
@@ -38,7 +38,7 @@ public struct CJSBridge: JSBridge {
     }
 
     // MARK: Functions
-    public static func call(function: JSObject.Ref, args: [RawJSValue]) -> ThrowingCallResult<RawJSValue> {
+    public static func call(function: JSObject.Ref, args: [RawJSValue]) -> JSThrowingCallResult<RawJSValue> {
         args.withUnsafeBufferPointer { args in
             var kindAndFlags = RawJSValue.KindWithFlags()
             let value = withRawJSValue { jsValue in
@@ -49,7 +49,7 @@ public struct CJSBridge: JSBridge {
         }
     }
 
-    public static func call(function: JSObject.Ref, this: JSObject.Ref, args: [RawJSValue]) -> ThrowingCallResult<RawJSValue> {
+    public static func call(function: JSObject.Ref, this: JSObject.Ref, args: [RawJSValue]) -> JSThrowingCallResult<RawJSValue> {
         args.withUnsafeBufferPointer { args in
             var kindAndFlags = RawJSValue.KindWithFlags()
             let value = withRawJSValue { jsValue in
@@ -66,7 +66,7 @@ public struct CJSBridge: JSBridge {
         }
     }
 
-    public static func throwingNew(class: JSObject.Ref, args: [RawJSValue]) -> ThrowingCallResult<JSObject.Ref> {
+    public static func throwingNew(class: JSObject.Ref, args: [RawJSValue]) -> JSThrowingCallResult<JSObject.Ref> {
         args.withUnsafeBufferPointer { args in
             var kindAndFlags = RawJSValue.KindWithFlags()
             var exception = RawJSValue()

--- a/Sources/JavaScriptKit/FundamentalObjects/CJSBridge.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/CJSBridge.swift
@@ -1,3 +1,5 @@
+import _CJavaScriptKit
+
 public enum CJSBridge: JSBridge {
     // MARK: Objects
     public static func set(on object: JSObject.Ref, property: JSObject.Ref, to value: RawJSValue) {

--- a/Sources/JavaScriptKit/FundamentalObjects/CJSBridge.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/CJSBridge.swift
@@ -84,8 +84,10 @@ public struct CJSBridge: JSBridge {
         _create_function(funcRef)
     }
 
-    public static func createTypedArray<Element: TypedArrayElement>(buffer: UnsafeBufferPointer<Element>) -> JSObject.Ref {
-        _create_typed_array(Element.typedArrayClass.id, buffer.baseAddress!, Int32(buffer.count))
+    public static func createTypedArray<Element: TypedArrayElement>(copying array: [Element]) -> JSObject.Ref {
+        array.withUnsafeBufferPointer { buffer in
+            _create_typed_array(Element.typedArrayClass.id, buffer.baseAddress!, Int32(buffer.count))
+        }
     }
 
     public static func release(_ obj: JSObject.Ref) {

--- a/Sources/JavaScriptKit/FundamentalObjects/CJSBridge.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/CJSBridge.swift
@@ -1,0 +1,101 @@
+public struct CJSBridge: JSBridge {
+    public static func set(on object: JSObject.Ref, property: JSObject.Ref, to value: RawJSValue) {
+        _set_prop(object, property, value.kind, value.payload1, value.payload2)
+    }
+
+    public static func get(on object: JSObject.Ref, property: JSObject.Ref) -> RawJSValue {
+        _withRawJSValue {
+            _get_prop(object, property, &$0.kind, &$0.payload1, &$0.payload2)
+        }
+    }
+
+    public static func set(on object: JSObject.Ref, index: Int32, to newValue: RawJSValue) {
+        _set_subscript(object, index, newValue.kind, newValue.payload1, newValue.payload2)
+    }
+    public static func get(on object: JSObject.Ref, index: Int32) -> RawJSValue {
+        _withRawJSValue {
+            _get_subscript(object, index, &$0.kind, &$0.payload1, &$0.payload2)
+        }
+    }
+
+    public static func encode(string: JSObject.Ref) -> String {
+        var bytesRef: JSObject.Ref = 0
+        let bytesLength = Int(_encode_string(string, &bytesRef))
+        defer { Self.release(bytesRef) }
+        // +1 for null terminator
+        let buffer = [UInt8].init(unsafeUninitializedCapacity: bytesLength + 1) { buffer, initializedCount in
+            _load_string(bytesRef, buffer.baseAddress)
+            buffer[bytesLength] = 0
+            initializedCount = bytesLength + 1
+        }
+        return String(decoding: buffer, as: UTF8.self)
+    }
+
+    public static func decode(string: inout String) -> JSObject.Ref {
+        string.withUTF8 {
+            _decode_string($0.baseAddress!, Int32($0.count))
+        }
+    }
+
+    public static func call(function: JSObject.Ref, args: [RawJSValue]) -> ThrowingCallResult<RawJSValue> {
+        args.withUnsafeBufferPointer { args in
+            var kindAndFlags = RawJSValue.KindWithFlags()
+            let value = _withRawJSValue { jsValue in
+                _call_function(function, args.baseAddress!, Int32(args.count), &kindAndFlags, &jsValue.payload1, &jsValue.payload2)
+                jsValue.kind = kindAndFlags.kind
+            }
+            return kindAndFlags.isException ? .exception(value) : .success(value)
+        }
+    }
+
+    public static func call(function: JSObject.Ref, this: JSObject.Ref, args: [RawJSValue]) -> ThrowingCallResult<RawJSValue> {
+        args.withUnsafeBufferPointer { args in
+            var kindAndFlags = RawJSValue.KindWithFlags()
+            let value = _withRawJSValue { jsValue in
+                _call_function_with_this(function, this, args.baseAddress!, Int32(args.count), &kindAndFlags, &jsValue.payload1, &jsValue.payload2)
+                jsValue.kind = kindAndFlags.kind
+            }
+            return kindAndFlags.isException ? .exception(value) : .success(value)
+        }
+    }
+
+    public static func new(class: JSObject.Ref, args: [RawJSValue]) -> JSObject.Ref {
+        args.withUnsafeBufferPointer { args in
+            _call_new(`class`, args.baseAddress!, Int32(args.count))
+        }
+    }
+
+    public static func throwingNew(class: JSObject.Ref, args: [RawJSValue]) -> ThrowingCallResult<JSObject.Ref> {
+        args.withUnsafeBufferPointer { args in
+            var kindAndFlags = RawJSValue.KindWithFlags()
+            var exception = RawJSValue()
+            let objectRef = _call_throwing_new(`class`, args.baseAddress!, Int32(args.count), &kindAndFlags, &exception.payload1, &exception.payload2)
+            exception.kind = kindAndFlags.kind
+            return kindAndFlags.isException ? .exception(exception) : .success(objectRef)
+        }
+    }
+
+
+    public static func instanceof(obj: JSObject.Ref, constructor: JSObject.Ref) -> Bool {
+        _instanceof(obj, constructor)
+    }
+
+    public static func createFunction(calling funcRef: JSClosure.Ref) -> JSObject.Ref {
+        _create_function(funcRef)
+    }
+
+    public static func createTypedArray<Element: TypedArrayElement>(buffer: UnsafeBufferPointer<Element>) -> JSObject.Ref {
+        _create_typed_array(Element.typedArrayClass.id, buffer.baseAddress!, Int32(buffer.count))
+    }
+
+    public static func release(_ obj: JSObject.Ref) {
+        _release(obj)
+    }
+
+    @inlinable public static func _withRawJSValue(perform: (inout RawJSValue) -> Void) -> RawJSValue {
+        var rawValue = RawJSValue()
+        perform(&rawValue)
+        return rawValue
+    }
+
+}

--- a/Sources/JavaScriptKit/FundamentalObjects/JSBridge.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSBridge.swift
@@ -40,7 +40,7 @@ public protocol JSBridge {
 
     // Misc
     static func instanceof(obj: JSObject.Ref, constructor: JSObject.Ref) -> Bool
-    static func createTypedArray<Element: TypedArrayElement>(copying array: [Element]) -> JSObject.Ref
+    static func createTypedArray<Element: TypedArrayElement>(copying array: [Element], as class: JSObject.Ref) -> JSObject.Ref
     static func release(_ obj: JSObject.Ref)
     static var globalThis: JSObject.Ref { get }
 }

--- a/Sources/JavaScriptKit/FundamentalObjects/JSBridge.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSBridge.swift
@@ -21,19 +21,34 @@ public enum ThrowingCallResult<T> {
 }
 
 public protocol JSBridge {
+    // Objects
     static func set(on object: JSObject.Ref, property: JSObject.Ref, to value: RawJSValue)
     static func get(on object: JSObject.Ref, index: Int32) -> RawJSValue
     static func set(on object: JSObject.Ref, index: Int32, to value: RawJSValue)
     static func get(on object: JSObject.Ref, property: JSObject.Ref) -> RawJSValue
+
+    // Strings
     static func encode(string: JSObject.Ref) -> String
     static func decode(string: inout String) -> JSObject.Ref // `inout` to enable the use of withUTF8(_:)
+
+    // Functions
     static func call(function: JSObject.Ref, args: [RawJSValue]) -> ThrowingCallResult<RawJSValue>
     static func call(function: JSObject.Ref, this: JSObject.Ref, args: [RawJSValue]) -> ThrowingCallResult<RawJSValue>
     static func new(class: JSObject.Ref, args: [RawJSValue]) -> JSObject.Ref
     static func throwingNew(class: JSObject.Ref, args: [RawJSValue]) -> ThrowingCallResult<JSObject.Ref>
-    static func instanceof(obj: JSObject.Ref, constructor: JSObject.Ref) -> Bool
     static func createFunction(calling: JSClosure.Ref) -> JSObject.Ref
+
+    // Misc
+    static func instanceof(obj: JSObject.Ref, constructor: JSObject.Ref) -> Bool
     static func createTypedArray<Element: TypedArrayElement>(copying array: [Element]) -> JSObject.Ref
     static func release(_ obj: JSObject.Ref)
-    static var globalRef: JSObject.Ref { get }
+    static var globalThis: JSObject.Ref { get }
+}
+
+extension JSBridge {
+    @inlinable public static func withRawJSValue(perform: (inout RawJSValue) -> Void) -> RawJSValue {
+        var rawValue = RawJSValue()
+        perform(&rawValue)
+        return rawValue
+    }
 }

--- a/Sources/JavaScriptKit/FundamentalObjects/JSBridge.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSBridge.swift
@@ -2,12 +2,7 @@ import Foundation
 import _CJavaScriptKit
 
 public typealias RawJSValue = _CJavaScriptKit.RawJSValue
-extension RawJSValue {
-    typealias Kind = _CJavaScriptKit.JavaScriptValueKind
-    typealias KindWithFlags = _CJavaScriptKit.JavaScriptValueKindAndFlags
-    typealias Payload1 = _CJavaScriptKit.JavaScriptPayload1
-    typealias Payload2 = _CJavaScriptKit.JavaScriptPayload2
-}
+
 extension JSObject {
     public typealias Ref = _CJavaScriptKit.JavaScriptObjectRef
 }

--- a/Sources/JavaScriptKit/FundamentalObjects/JSBridge.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSBridge.swift
@@ -13,6 +13,15 @@ extension JSClosure {
 public enum JSThrowingCallResult<T> {
     case success(T)
     case exception(RawJSValue)
+
+    func get(using bridge: JSBridge.Type) throws -> T {
+        switch self {
+        case .success(let value):
+            return value
+        case .exception(let rawValue):
+            throw rawValue.jsValue(using: bridge)
+        }
+    }
 }
 
 public protocol JSBridge {

--- a/Sources/JavaScriptKit/FundamentalObjects/JSBridge.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSBridge.swift
@@ -26,15 +26,14 @@ public protocol JSBridge {
     static func set(on object: JSObject.Ref, index: Int32, to value: RawJSValue)
     static func get(on object: JSObject.Ref, property: JSObject.Ref) -> RawJSValue
     static func encode(string: JSObject.Ref) -> String
-    // `inout` to enable the use of withUTF8(_:)
-    static func decode(string: inout String) -> JSObject.Ref
+    static func decode(string: inout String) -> JSObject.Ref // `inout` to enable the use of withUTF8(_:)
     static func call(function: JSObject.Ref, args: [RawJSValue]) -> ThrowingCallResult<RawJSValue>
     static func call(function: JSObject.Ref, this: JSObject.Ref, args: [RawJSValue]) -> ThrowingCallResult<RawJSValue>
     static func new(class: JSObject.Ref, args: [RawJSValue]) -> JSObject.Ref
     static func throwingNew(class: JSObject.Ref, args: [RawJSValue]) -> ThrowingCallResult<JSObject.Ref>
     static func instanceof(obj: JSObject.Ref, constructor: JSObject.Ref) -> Bool
     static func createFunction(calling: JSClosure.Ref) -> JSObject.Ref
-    static func createTypedArray<Element: TypedArrayElement>(buffer: UnsafeBufferPointer<Element>) -> JSObject.Ref
+    static func createTypedArray<Element: TypedArrayElement>(copying array: [Element]) -> JSObject.Ref
     static func release(_ obj: JSObject.Ref)
     static var globalRef: JSObject.Ref { get }
 }

--- a/Sources/JavaScriptKit/FundamentalObjects/JSBridge.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSBridge.swift
@@ -36,4 +36,5 @@ public protocol JSBridge {
     static func createFunction(calling: JSClosure.Ref) -> JSObject.Ref
     static func createTypedArray<Element: TypedArrayElement>(buffer: UnsafeBufferPointer<Element>) -> JSObject.Ref
     static func release(_ obj: JSObject.Ref)
+    static var globalRef: JSObject.Ref { get }
 }

--- a/Sources/JavaScriptKit/FundamentalObjects/JSBridge.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSBridge.swift
@@ -15,7 +15,7 @@ extension JSClosure {
     public typealias Ref = _CJavaScriptKit.JavaScriptHostFuncRef
 }
 
-public enum ThrowingCallResult<T> {
+public enum JSThrowingCallResult<T> {
     case success(T)
     case exception(RawJSValue)
 }
@@ -32,10 +32,10 @@ public protocol JSBridge {
     static func decode(string: inout String) -> JSObject.Ref // `inout` to enable the use of withUTF8(_:)
 
     // Functions
-    static func call(function: JSObject.Ref, args: [RawJSValue]) -> ThrowingCallResult<RawJSValue>
-    static func call(function: JSObject.Ref, this: JSObject.Ref, args: [RawJSValue]) -> ThrowingCallResult<RawJSValue>
+    static func call(function: JSObject.Ref, args: [RawJSValue]) -> JSThrowingCallResult<RawJSValue>
+    static func call(function: JSObject.Ref, this: JSObject.Ref, args: [RawJSValue]) -> JSThrowingCallResult<RawJSValue>
     static func new(class: JSObject.Ref, args: [RawJSValue]) -> JSObject.Ref
-    static func throwingNew(class: JSObject.Ref, args: [RawJSValue]) -> ThrowingCallResult<JSObject.Ref>
+    static func throwingNew(class: JSObject.Ref, args: [RawJSValue]) -> JSThrowingCallResult<JSObject.Ref>
     static func createFunction(calling: JSClosure.Ref) -> JSObject.Ref
 
     // Misc

--- a/Sources/JavaScriptKit/FundamentalObjects/JSBridge.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSBridge.swift
@@ -1,0 +1,39 @@
+import Foundation
+import _CJavaScriptKit
+
+public typealias RawJSValue = _CJavaScriptKit.RawJSValue
+extension RawJSValue {
+    typealias Kind = _CJavaScriptKit.JavaScriptValueKind
+    typealias KindWithFlags = _CJavaScriptKit.JavaScriptValueKindAndFlags
+    typealias Payload1 = _CJavaScriptKit.JavaScriptPayload1
+    typealias Payload2 = _CJavaScriptKit.JavaScriptPayload2
+}
+extension JSObject {
+    public typealias Ref = _CJavaScriptKit.JavaScriptObjectRef
+}
+extension JSClosure {
+    public typealias Ref = _CJavaScriptKit.JavaScriptHostFuncRef
+}
+
+public enum ThrowingCallResult<T> {
+    case success(T)
+    case exception(RawJSValue)
+}
+
+public protocol JSBridge {
+    static func set(on object: JSObject.Ref, property: JSObject.Ref, to value: RawJSValue)
+    static func get(on object: JSObject.Ref, index: Int32) -> RawJSValue
+    static func set(on object: JSObject.Ref, index: Int32, to value: RawJSValue)
+    static func get(on object: JSObject.Ref, property: JSObject.Ref) -> RawJSValue
+    static func encode(string: JSObject.Ref) -> String
+    // `inout` to enable the use of withUTF8(_:)
+    static func decode(string: inout String) -> JSObject.Ref
+    static func call(function: JSObject.Ref, args: [RawJSValue]) -> ThrowingCallResult<RawJSValue>
+    static func call(function: JSObject.Ref, this: JSObject.Ref, args: [RawJSValue]) -> ThrowingCallResult<RawJSValue>
+    static func new(class: JSObject.Ref, args: [RawJSValue]) -> JSObject.Ref
+    static func throwingNew(class: JSObject.Ref, args: [RawJSValue]) -> ThrowingCallResult<JSObject.Ref>
+    static func instanceof(obj: JSObject.Ref, constructor: JSObject.Ref) -> Bool
+    static func createFunction(calling: JSClosure.Ref) -> JSObject.Ref
+    static func createTypedArray<Element: TypedArrayElement>(buffer: UnsafeBufferPointer<Element>) -> JSObject.Ref
+    static func release(_ obj: JSObject.Ref)
+}

--- a/Sources/JavaScriptKit/FundamentalObjects/JSClosure.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSClosure.swift
@@ -136,7 +136,7 @@ func _call_host_function_impl(
         fatalError("The function was already released")
     }
     let arguments = UnsafeBufferPointer(start: argv, count: Int(argc)).map {
-        $0.jsValue()
+        $0.jsValue(using: closure.bridge)
     }
     let result = hostFunc(arguments)
     let callbackFuncRef = JSFunction(id: callbackFuncRef, using: closure.bridge)

--- a/Sources/JavaScriptKit/FundamentalObjects/JSFunction.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSFunction.swift
@@ -92,8 +92,8 @@ internal func invokeJSFunction(_ jsFunc: JSFunction, arguments: [ConvertibleToJS
     }
     switch result {
     case .exception(let exception):
-        throw exception.jsValue()
+        throw exception.jsValue(using: bridge)
     case .success(let value):
-        return value.jsValue()
+        return value.jsValue(using: bridge)
     }
 }

--- a/Sources/JavaScriptKit/FundamentalObjects/JSFunction.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSFunction.swift
@@ -83,7 +83,7 @@ public class JSFunction: JSObject {
 }
 
 internal func invokeJSFunction(_ jsFunc: JSFunction, arguments: [ConvertibleToJSValue], this: JSObject?, using bridge: JSBridge.Type = CJSBridge.self) throws -> JSValue {
-    let result = arguments.withRawJSValues { (rawValues) -> ThrowingCallResult<RawJSValue> in
+    let result: JSThrowingCallResult<RawJSValue> = arguments.withRawJSValues { (rawValues) in
         if let thisId = this?.id {
             return bridge.call(function: jsFunc.id, this: thisId, args: rawValues)
         } else {

--- a/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
@@ -60,24 +60,24 @@ public class JSObject: Equatable {
     /// - Parameter name: The name of this object's member to access.
     /// - Returns: The value of the `name` member of this object.
     public subscript(_ name: String) -> JSValue {
-        get { getJSValue(this: self, name: JSString(name), using: bridge) }
-        set { setJSValue(this: self, name: JSString(name), value: newValue, using: bridge) }
+        get { getJSValue(this: self, name: JSString(name)) }
+        set { setJSValue(this: self, name: JSString(name), value: newValue) }
     }
 
     /// Access the `name` member dynamically through JavaScript and Swift runtime bridge library.
     /// - Parameter name: The name of this object's member to access.
     /// - Returns: The value of the `name` member of this object.
     public subscript(_ name: JSString) -> JSValue {
-        get { getJSValue(this: self, name: name, using: bridge) }
-        set { setJSValue(this: self, name: name, value: newValue, using: bridge) }
+        get { getJSValue(this: self, name: name) }
+        set { setJSValue(this: self, name: name, value: newValue) }
     }
 
     /// Access the `index` member dynamically through JavaScript and Swift runtime bridge library.
     /// - Parameter index: The index of this object's member to access.
     /// - Returns: The value of the `index` member of this object.
     public subscript(_ index: Int) -> JSValue {
-        get { getJSValue(this: self, index: Int32(index), using: bridge) }
-        set { setJSValue(this: self, index: Int32(index), value: newValue, using: bridge) }
+        get { getJSValue(this: self, index: Int32(index)) }
+        set { setJSValue(this: self, index: Int32(index), value: newValue) }
     }
 
     /// A modifier to call methods as throwing methods capturing `this`
@@ -105,7 +105,8 @@ public class JSObject: Equatable {
     /// - Parameter constructor: The constructor function to check.
     /// - Returns: The result of `instanceof` in the JavaScript environment.
     public func isInstanceOf(_ constructor: JSFunction) -> Bool {
-        bridge.instanceof(obj: self.id, constructor: constructor.id)
+        assert(self.bridge == constructor.bridge, "JSBridge mismatch: \(self.bridge) != \(constructor.bridge)")
+        return bridge.instanceof(obj: self.id, constructor: constructor.id)
     }
 
 

--- a/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
@@ -108,14 +108,13 @@ public class JSObject: Equatable {
         bridge.instanceof(obj: self.id, constructor: constructor.id)
     }
 
-    static let _JS_Predef_Value_Global: JavaScriptObjectRef = 0
 
     /// A `JSObject` of the global scope object.
     /// This allows access to the global properties and global names by accessing the `JSObject` returned.
-    public static let global = JSObject(id: _JS_Predef_Value_Global, using: CJSBridge.self)
+    public static let global = JSObject(id: CJSBridge.globalRef, using: CJSBridge.self)
 
     public static func global(using bridge: JSBridge.Type) -> JSObject {
-        JSObject(id: _JS_Predef_Value_Global, using: bridge)
+        JSObject(id: bridge.globalRef, using: bridge)
     }
 
     deinit { bridge.release(id) }

--- a/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
@@ -111,10 +111,10 @@ public class JSObject: Equatable {
 
     /// A `JSObject` of the global scope object.
     /// This allows access to the global properties and global names by accessing the `JSObject` returned.
-    public static let global = JSObject(id: CJSBridge.globalRef, using: CJSBridge.self)
+    public static let global = JSObject.global(using: CJSBridge.self)
 
     public static func global(using bridge: JSBridge.Type) -> JSObject {
-        JSObject(id: bridge.globalRef, using: bridge)
+        JSObject(id: bridge.globalThis, using: bridge)
     }
 
     deinit { bridge.release(id) }

--- a/Sources/JavaScriptKit/FundamentalObjects/JSThrowingFunction.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSThrowingFunction.swift
@@ -41,9 +41,9 @@ public class JSThrowingFunction {
                 let argv = bufferPointer.baseAddress
                 let argc = bufferPointer.count
 
-                var exceptionKind = JavaScriptValueKindAndFlags()
-                var exceptionPayload1 = JavaScriptPayload1()
-                var exceptionPayload2 = JavaScriptPayload2()
+                var exceptionKind = RawJSValue.KindAndFlags()
+                var exceptionPayload1 = RawJSValue.Payload1()
+                var exceptionPayload2 = RawJSValue.Payload2()
                 let resultObj = _call_throwing_new(
                     self.base.id, argv, Int32(argc),
                     &exceptionKind, &exceptionPayload1, &exceptionPayload2

--- a/Sources/JavaScriptKit/FundamentalObjects/JSThrowingFunction.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSThrowingFunction.swift
@@ -50,7 +50,7 @@ public class JSThrowingFunction {
                 )
                 if exceptionKind.isException {
                     let exception = RawJSValue(kind: exceptionKind.kind, payload1: exceptionPayload1, payload2: exceptionPayload2)
-                    return .failure(exception.jsValue())
+                    return .failure(exception.jsValue(using: base.bridge))
                 }
                 return .success(JSObject(id: resultObj, using: base.bridge))
             }

--- a/Sources/JavaScriptKit/FundamentalObjects/JSThrowingFunction.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSThrowingFunction.swift
@@ -36,15 +36,10 @@ public class JSThrowingFunction {
     /// - Parameter arguments: Arguments to be passed to this constructor function.
     /// - Returns: A new instance of this constructor.
     public func new(arguments: [ConvertibleToJSValue]) throws -> JSObject {
-        let result = arguments.withRawJSValues(using: base.bridge) { rawValues in
+        let ref = try arguments.withRawJSValues(using: base.bridge) { rawValues in
             base.bridge.throwingNew(class: base.id, args: rawValues)
-        }
-        switch result {
-        case .success(let id):
-            return JSObject(id: id, using: base.bridge)
-        case .exception(let error):
-            throw error.jsValue(using: base.bridge)
-        }
+        }.get(using: base.bridge)
+        return JSObject(id: ref, using: base.bridge)
     }
 
     /// A variadic arguments version of `new`.

--- a/Sources/JavaScriptKit/FundamentalObjects/JSThrowingFunction.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSThrowingFunction.swift
@@ -52,7 +52,7 @@ public class JSThrowingFunction {
                     let exception = RawJSValue(kind: exceptionKind.kind, payload1: exceptionPayload1, payload2: exceptionPayload2)
                     return .failure(exception.jsValue())
                 }
-                return .success(JSObject(id: resultObj))
+                return .success(JSObject(id: resultObj, using: base.bridge))
             }
         }.get()
     }

--- a/Sources/JavaScriptKit/JSValue.swift
+++ b/Sources/JavaScriptKit/JSValue.swift
@@ -174,7 +174,7 @@ extension JSValue: ExpressibleByNilLiteral {
 }
 
 public func getJSValue(this: JSObject, name: JSString, using bridge: JSBridge.Type = CJSBridge.self) -> JSValue {
-    bridge.get(on: this.id, property: name.asInternalJSRef()).jsValue()
+    bridge.get(on: this.id, property: name.asInternalJSRef()).jsValue(using: bridge)
 }
 
 public func setJSValue(this: JSObject, name: JSString, value: JSValue, using bridge: JSBridge.Type = CJSBridge.self) {
@@ -184,7 +184,7 @@ public func setJSValue(this: JSObject, name: JSString, value: JSValue, using bri
 }
 
 public func getJSValue(this: JSObject, index: Int32, using bridge: JSBridge.Type = CJSBridge.self) -> JSValue {
-    bridge.get(on: this.id, index: index).jsValue()
+    bridge.get(on: this.id, index: index).jsValue(using: bridge)
 }
 
 public func setJSValue(this: JSObject, index: Int32, value: JSValue, using bridge: JSBridge.Type = CJSBridge.self) {

--- a/Sources/JavaScriptKit/JSValue.swift
+++ b/Sources/JavaScriptKit/JSValue.swift
@@ -1,5 +1,3 @@
-import _CJavaScriptKit
-
 /// `JSValue` represents a value in JavaScript.
 @dynamicMemberLookup
 public enum JSValue: Equatable {
@@ -175,33 +173,23 @@ extension JSValue: ExpressibleByNilLiteral {
     }
 }
 
-public func getJSValue(this: JSObject, name: JSString) -> JSValue {
-    var rawValue = RawJSValue()
-    _get_prop(this.id, name.asInternalJSRef(),
-              &rawValue.kind,
-              &rawValue.payload1, &rawValue.payload2)
-    return rawValue.jsValue()
+public func getJSValue(this: JSObject, name: JSString, using bridge: JSBridge.Type = CJSBridge.self) -> JSValue {
+    bridge.get(on: this.id, property: name.asInternalJSRef()).jsValue()
 }
 
-public func setJSValue(this: JSObject, name: JSString, value: JSValue) {
+public func setJSValue(this: JSObject, name: JSString, value: JSValue, using bridge: JSBridge.Type = CJSBridge.self) {
     value.withRawJSValue { rawValue in
-        _set_prop(this.id, name.asInternalJSRef(), rawValue.kind, rawValue.payload1, rawValue.payload2)
+        bridge.set(on: this.id, property: name.asInternalJSRef(), to: rawValue)
     }
 }
 
-public func getJSValue(this: JSObject, index: Int32) -> JSValue {
-    var rawValue = RawJSValue()
-    _get_subscript(this.id, index,
-                   &rawValue.kind,
-                   &rawValue.payload1, &rawValue.payload2)
-    return rawValue.jsValue()
+public func getJSValue(this: JSObject, index: Int32, using bridge: JSBridge.Type = CJSBridge.self) -> JSValue {
+    bridge.get(on: this.id, index: index).jsValue()
 }
 
-public func setJSValue(this: JSObject, index: Int32, value: JSValue) {
+public func setJSValue(this: JSObject, index: Int32, value: JSValue, using bridge: JSBridge.Type = CJSBridge.self) {
     value.withRawJSValue { rawValue in
-        _set_subscript(this.id, index,
-                       rawValue.kind,
-                       rawValue.payload1, rawValue.payload2)
+        bridge.set(on: this.id, index: index, to: rawValue)
     }
 }
 

--- a/Sources/JavaScriptKit/JSValue.swift
+++ b/Sources/JavaScriptKit/JSValue.swift
@@ -178,10 +178,10 @@ public func getJSValue(this: JSObject, name: JSString) -> JSValue {
     return this.bridge.get(on: this.id, property: name.asInternalJSRef()).jsValue(using: this.bridge)
 }
 
-public func setJSValue(this: JSObject, name: JSString, value: JSValue, using bridge: JSBridge.Type = CJSBridge.self) {
+public func setJSValue(this: JSObject, name: JSString, value: JSValue) {
     assert(this.bridge == name.guts.bridge, "JSBridge mismatch: \(this.bridge) != \(name.guts.bridge)")
     value.withRawJSValue { rawValue in
-        bridge.set(on: this.id, property: name.asInternalJSRef(), to: rawValue)
+        this.bridge.set(on: this.id, property: name.asInternalJSRef(), to: rawValue)
     }
 }
 

--- a/Sources/JavaScriptKit/XcodeSupport.swift
+++ b/Sources/JavaScriptKit/XcodeSupport.swift
@@ -9,30 +9,30 @@ import _CJavaScriptKit
     func _set_prop(
         _: JavaScriptObjectRef,
         _: JavaScriptObjectRef,
-        _: JavaScriptValueKind,
-        _: JavaScriptPayload1,
-        _: JavaScriptPayload2
+        _: RawJSValue.Kind,
+        _: RawJSValue.Payload1,
+        _: RawJSValue.Payload2
     ) { fatalError() }
     func _get_prop(
         _: JavaScriptObjectRef,
         _: JavaScriptObjectRef,
-        _: UnsafeMutablePointer<JavaScriptValueKind>!,
-        _: UnsafeMutablePointer<JavaScriptPayload1>!,
-        _: UnsafeMutablePointer<JavaScriptPayload2>!
+        _: UnsafeMutablePointer<RawJSValue.Kind>!,
+        _: UnsafeMutablePointer<RawJSValue.Payload1>!,
+        _: UnsafeMutablePointer<RawJSValue.Payload2>!
     ) { fatalError() }
     func _set_subscript(
         _: JavaScriptObjectRef,
         _: Int32,
-        _: JavaScriptValueKind,
-        _: JavaScriptPayload1,
-        _: JavaScriptPayload2
+        _: RawJSValue.Kind,
+        _: RawJSValue.Payload1,
+        _: RawJSValue.Payload2
     ) { fatalError() }
     func _get_subscript(
         _: JavaScriptObjectRef,
         _: Int32,
-        _: UnsafeMutablePointer<JavaScriptValueKind>!,
-        _: UnsafeMutablePointer<JavaScriptPayload1>!,
-        _: UnsafeMutablePointer<JavaScriptPayload2>!
+        _: UnsafeMutablePointer<RawJSValue.Kind>!,
+        _: UnsafeMutablePointer<RawJSValue.Payload1>!,
+        _: UnsafeMutablePointer<RawJSValue.Payload2>!
     ) { fatalError() }
     func _encode_string(
         _: JavaScriptObjectRef,
@@ -49,17 +49,17 @@ import _CJavaScriptKit
     func _call_function(
         _: JavaScriptObjectRef,
         _: UnsafePointer<RawJSValue>!, _: Int32,
-        _: UnsafeMutablePointer<JavaScriptValueKindAndFlags>!,
-        _: UnsafeMutablePointer<JavaScriptPayload1>!,
-        _: UnsafeMutablePointer<JavaScriptPayload2>!
+        _: UnsafeMutablePointer<RawJSValue.KindAndFlags>!,
+        _: UnsafeMutablePointer<RawJSValue.Payload1>!,
+        _: UnsafeMutablePointer<RawJSValue.Payload2>!
     ) { fatalError() }
     func _call_function_with_this(
         _: JavaScriptObjectRef,
         _: JavaScriptObjectRef,
         _: UnsafePointer<RawJSValue>!, _: Int32,
-        _: UnsafeMutablePointer<JavaScriptValueKindAndFlags>!,
-        _: UnsafeMutablePointer<JavaScriptPayload1>!,
-        _: UnsafeMutablePointer<JavaScriptPayload2>!
+        _: UnsafeMutablePointer<RawJSValue.KindAndFlags>!,
+        _: UnsafeMutablePointer<RawJSValue.Payload1>!,
+        _: UnsafeMutablePointer<RawJSValue.Payload2>!
     ) { fatalError() }
     func _call_new(
         _: JavaScriptObjectRef,
@@ -68,9 +68,9 @@ import _CJavaScriptKit
     func _call_throwing_new(
         _: JavaScriptObjectRef,
         _: UnsafePointer<RawJSValue>!, _: Int32,
-        _: UnsafeMutablePointer<JavaScriptValueKindAndFlags>!,
-        _: UnsafeMutablePointer<JavaScriptPayload1>!,
-        _: UnsafeMutablePointer<JavaScriptPayload2>!
+        _: UnsafeMutablePointer<RawJSValue.KindAndFlags>!,
+        _: UnsafeMutablePointer<RawJSValue.Payload1>!,
+        _: UnsafeMutablePointer<RawJSValue.Payload2>!
     ) -> JavaScriptObjectRef { fatalError() }
     func _instanceof(
         _: JavaScriptObjectRef,

--- a/Sources/_CJavaScriptKit/include/_CJavaScriptKit.h
+++ b/Sources/_CJavaScriptKit/include/_CJavaScriptKit.h
@@ -21,15 +21,15 @@ typedef enum __attribute__((enum_extensibility(closed))) {
   JavaScriptValueKindNull = 4,
   JavaScriptValueKindUndefined = 5,
   JavaScriptValueKindFunction = 6,
-} JavaScriptValueKind;
+} JavaScriptValueKind __attribute__((swift_name("RawJSValue.Kind")));
 
 typedef struct {
   JavaScriptValueKind kind: 31;
   bool isException: 1;
-} JavaScriptValueKindAndFlags;
+} JavaScriptValueKindAndFlags __attribute__((swift_name("RawJSValue.KindAndFlags")));
 
-typedef unsigned JavaScriptPayload1;
-typedef double JavaScriptPayload2;
+typedef unsigned JavaScriptPayload1 __attribute__((swift_name("RawJSValue.Payload1")));
+typedef double JavaScriptPayload2 __attribute__((swift_name("RawJSValue.Payload2")));
 
 /// `RawJSValue` is abstract representaion of JavaScript primitive value.
 ///


### PR DESCRIPTION
To use this API, first define a enum or struct conforming to `JSBridge` and define the required methods. Then, call `JSObject.global(using: MyJSBridge.self)` to get the global object.

Currently, `JSTypedArray` and `JSBridgedClass` only work with the default bridge, but I didn’t want to put too much effort into figuring out how to get those APIs to work properly if this approach didn’t end up getting accepted.