### PR TITLE
Split runtime into multiple files

### DIFF
--- a/Runtime/rollup.config.js
+++ b/Runtime/rollup.config.js
@@ -1,0 +1,13 @@
+import typescript from "@rollup/plugin-typescript";
+
+/** @type {import('rollup').RollupOptions} */
+const config = {
+    input: "src/index.ts",
+    output: {
+        dir: "lib",
+        format: "cjs",
+    },
+    plugins: [typescript()],
+};
+
+export default config;

--- a/Runtime/rollup.config.js
+++ b/Runtime/rollup.config.js
@@ -5,7 +5,8 @@ const config = {
     input: "src/index.ts",
     output: {
         dir: "lib",
-        format: "cjs",
+        format: "umd",
+        name: "JavaScriptKit",
     },
     plugins: [typescript()],
 };

--- a/Runtime/rollup.config.js
+++ b/Runtime/rollup.config.js
@@ -3,11 +3,17 @@ import typescript from "@rollup/plugin-typescript";
 /** @type {import('rollup').RollupOptions} */
 const config = {
     input: "src/index.ts",
-    output: {
-        dir: "lib",
-        format: "umd",
-        name: "JavaScriptKit",
-    },
+    output: [
+        {
+            file: "lib/index.mjs",
+            format: "esm",
+        },
+        {
+            dir: "lib",
+            format: "umd",
+            name: "JavaScriptKit",
+        },
+    ],
     plugins: [typescript()],
 };
 

--- a/Runtime/src/closure-heap.ts
+++ b/Runtime/src/closure-heap.ts
@@ -1,10 +1,10 @@
-import { SwiftRuntimeExportedFunctions } from "./types";
+import { ExportedFunctions } from "./types";
 
 /// Memory lifetime of closures in Swift are managed by Swift side
 export class SwiftClosureDeallocator {
     private functionRegistry: FinalizationRegistry<number>;
 
-    constructor(exports: SwiftRuntimeExportedFunctions) {
+    constructor(exports: ExportedFunctions) {
         if (typeof FinalizationRegistry === "undefined") {
             throw new Error(
                 "The Swift part of JavaScriptKit was configured to require the availability of JavaScript WeakRefs. Please build with `-Xswiftc -DJAVASCRIPTKIT_WITHOUT_WEAKREFS` to disable features that use WeakRefs."

--- a/Runtime/src/closure-heap.ts
+++ b/Runtime/src/closure-heap.ts
@@ -1,0 +1,16 @@
+import { SwiftRuntimeExportedFunctions } from "./types";
+
+/// Memory lifetime of closures in Swift are managed by Swift side
+export class SwiftClosureHeap {
+    private functionRegistry: FinalizationRegistry<number>;
+
+    constructor(exports: SwiftRuntimeExportedFunctions) {
+        this.functionRegistry = new FinalizationRegistry((id) => {
+            exports.swjs_free_host_function(id);
+        });
+    }
+
+    alloc(func: any, func_ref: number) {
+        this.functionRegistry.register(func, func_ref);
+    }
+}

--- a/Runtime/src/closure-heap.ts
+++ b/Runtime/src/closure-heap.ts
@@ -7,7 +7,10 @@ export class SwiftClosureDeallocator {
     constructor(exports: ExportedFunctions) {
         if (typeof FinalizationRegistry === "undefined") {
             throw new Error(
-                "The Swift part of JavaScriptKit was configured to require the availability of JavaScript WeakRefs. Please build with `-Xswiftc -DJAVASCRIPTKIT_WITHOUT_WEAKREFS` to disable features that use WeakRefs."
+                "The Swift part of JavaScriptKit was configured to require " +
+                    "the availability of JavaScript WeakRefs. Please build " +
+                    "with `-Xswiftc -DJAVASCRIPTKIT_WITHOUT_WEAKREFS` to " +
+                    "disable features that use WeakRefs."
             );
         }
 

--- a/Runtime/src/closure-heap.ts
+++ b/Runtime/src/closure-heap.ts
@@ -1,7 +1,7 @@
 import { SwiftRuntimeExportedFunctions } from "./types";
 
 /// Memory lifetime of closures in Swift are managed by Swift side
-export class SwiftClosureHeap {
+export class SwiftClosureDeallocator {
     private functionRegistry: FinalizationRegistry<number>;
 
     constructor(exports: SwiftRuntimeExportedFunctions) {
@@ -16,7 +16,7 @@ export class SwiftClosureHeap {
         });
     }
 
-    alloc(func: any, func_ref: number) {
+    track(func: Function, func_ref: number) {
         this.functionRegistry.register(func, func_ref);
     }
 }

--- a/Runtime/src/closure-heap.ts
+++ b/Runtime/src/closure-heap.ts
@@ -5,6 +5,12 @@ export class SwiftClosureHeap {
     private functionRegistry: FinalizationRegistry<number>;
 
     constructor(exports: SwiftRuntimeExportedFunctions) {
+        if (typeof FinalizationRegistry === "undefined") {
+            throw new Error(
+                "The Swift part of JavaScriptKit was configured to require the availability of JavaScript WeakRefs. Please build with `-Xswiftc -DJAVASCRIPTKIT_WITHOUT_WEAKREFS` to disable features that use WeakRefs."
+            );
+        }
+
         this.functionRegistry = new FinalizationRegistry((id) => {
             exports.swjs_free_host_function(id);
         });

--- a/Runtime/src/find-global.ts
+++ b/Runtime/src/find-global.ts
@@ -1,0 +1,13 @@
+interface GlobalVariable {}
+declare const global: GlobalVariable;
+
+export let globalVariable: any;
+if (typeof globalThis !== "undefined") {
+    globalVariable = globalThis;
+} else if (typeof window !== "undefined") {
+    globalVariable = window;
+} else if (typeof global !== "undefined") {
+    globalVariable = global;
+} else if (typeof self !== "undefined") {
+    globalVariable = self;
+}

--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -57,16 +57,9 @@ export class SwiftRuntime {
         const librarySupportsWeakRef =
             (features & LibraryFeatures.WeakRefs) != 0;
         if (librarySupportsWeakRef) {
-            if (typeof FinalizationRegistry !== "undefined") {
-                this._closureHeap = new SwiftClosureHeap(this.exports);
-                return this._closureHeap;
-            } else {
-                throw new Error(
-                    "The Swift part of JavaScriptKit was configured to require the availability of JavaScript WeakRefs. Please build with `-Xswiftc -DJAVASCRIPTKIT_WITHOUT_WEAKREFS` to disable features that use WeakRefs."
-                );
-            }
+            this._closureHeap = new SwiftClosureHeap(this.exports);
         }
-        return null;
+        return this._closureHeap;
     }
 
     importObjects() {

--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -190,7 +190,7 @@ export class SwiftRuntime {
             this.memory.writeBytes(buffer, bytes);
         },
 
-        _swjs_call_function: (
+        swjs_call_function: (
             ref: ref,
             argv: pointer,
             argc: number,
@@ -225,12 +225,6 @@ export class SwiftRuntime {
                 false,
                 this.memory
             );
-        },
-        get swjs_call_function() {
-            return this._swjs_call_function;
-        },
-        set swjs_call_function(value) {
-            this._swjs_call_function = value;
         },
 
         swjs_call_function_with_this: (

--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -6,12 +6,7 @@ import {
     pointer,
     TypedArray,
 } from "./types";
-import {
-    decodeJSValue,
-    decodeJSValueArray,
-    JavaScriptValueKind,
-    writeJSValue,
-} from "./js-value";
+import * as JSValue from "./js-value";
 import { Memory } from "./memory";
 
 export class SwiftRuntime {
@@ -77,7 +72,7 @@ export class SwiftRuntime {
         for (let index = 0; index < args.length; index++) {
             const argument = args[index];
             const base = argv + 16 * index;
-            writeJSValue(
+            JSValue.write(
                 argument,
                 base,
                 base + 4,
@@ -108,7 +103,7 @@ export class SwiftRuntime {
         swjs_set_prop: (
             ref: ref,
             name: ref,
-            kind: JavaScriptValueKind,
+            kind: JSValue.Kind,
             payload1: number,
             payload2: number
         ) => {
@@ -116,7 +111,7 @@ export class SwiftRuntime {
             Reflect.set(
                 obj,
                 this.memory.getObject(name),
-                decodeJSValue(kind, payload1, payload2, this.memory)
+                JSValue.decode(kind, payload1, payload2, this.memory)
             );
         },
 
@@ -129,7 +124,7 @@ export class SwiftRuntime {
         ) => {
             const obj = this.memory.getObject(ref);
             const result = Reflect.get(obj, this.memory.getObject(name));
-            writeJSValue(
+            JSValue.write(
                 result,
                 kind_ptr,
                 payload1_ptr,
@@ -142,7 +137,7 @@ export class SwiftRuntime {
         swjs_set_subscript: (
             ref: ref,
             index: number,
-            kind: JavaScriptValueKind,
+            kind: JSValue.Kind,
             payload1: number,
             payload2: number
         ) => {
@@ -150,7 +145,7 @@ export class SwiftRuntime {
             Reflect.set(
                 obj,
                 index,
-                decodeJSValue(kind, payload1, payload2, this.memory)
+                JSValue.decode(kind, payload1, payload2, this.memory)
             );
         },
 
@@ -163,7 +158,7 @@ export class SwiftRuntime {
         ) => {
             const obj = this.memory.getObject(ref);
             const result = Reflect.get(obj, index);
-            writeJSValue(
+            JSValue.write(
                 result,
                 kind_ptr,
                 payload1_ptr,
@@ -208,10 +203,10 @@ export class SwiftRuntime {
                 result = Reflect.apply(
                     func,
                     undefined,
-                    decodeJSValueArray(argv, argc, this.memory)
+                    JSValue.decodeArray(argv, argc, this.memory)
                 );
             } catch (error) {
-                writeJSValue(
+                JSValue.write(
                     error,
                     kind_ptr,
                     payload1_ptr,
@@ -221,7 +216,7 @@ export class SwiftRuntime {
                 );
                 return;
             }
-            writeJSValue(
+            JSValue.write(
                 result,
                 kind_ptr,
                 payload1_ptr,
@@ -253,10 +248,10 @@ export class SwiftRuntime {
                 result = Reflect.apply(
                     func,
                     obj,
-                    decodeJSValueArray(argv, argc, this.memory)
+                    JSValue.decodeArray(argv, argc, this.memory)
                 );
             } catch (error) {
-                writeJSValue(
+                JSValue.write(
                     error,
                     kind_ptr,
                     payload1_ptr,
@@ -266,7 +261,7 @@ export class SwiftRuntime {
                 );
                 return;
             }
-            writeJSValue(
+            JSValue.write(
                 result,
                 kind_ptr,
                 payload1_ptr,
@@ -279,7 +274,7 @@ export class SwiftRuntime {
             const constructor = this.memory.getObject(ref);
             const instance = Reflect.construct(
                 constructor,
-                decodeJSValueArray(argv, argc, this.memory)
+                JSValue.decodeArray(argv, argc, this.memory)
             );
             return this.memory.retain(instance);
         },
@@ -297,10 +292,10 @@ export class SwiftRuntime {
             try {
                 result = Reflect.construct(
                     constructor,
-                    decodeJSValueArray(argv, argc, this.memory)
+                    JSValue.decodeArray(argv, argc, this.memory)
                 );
             } catch (error) {
-                writeJSValue(
+                JSValue.write(
                     error,
                     exception_kind_ptr,
                     exception_payload1_ptr,
@@ -310,7 +305,7 @@ export class SwiftRuntime {
                 );
                 return -1;
             }
-            writeJSValue(
+            JSValue.write(
                 null,
                 exception_kind_ptr,
                 exception_payload1_ptr,

--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -40,13 +40,13 @@ export class SwiftRuntime {
         }
     }
 
-    get instance() {
+    private get instance() {
         if (!this._instance)
             throw new Error("WebAssembly instance is not set yet");
         return this._instance;
     }
 
-    get exports() {
+    private get exports() {
         return this.instance.exports as any as SwiftRuntimeExportedFunctions;
     }
 
@@ -57,7 +57,7 @@ export class SwiftRuntime {
         return this._memory;
     }
 
-    get closureDeallocator(): SwiftClosureDeallocator | null {
+    private get closureDeallocator(): SwiftClosureDeallocator | null {
         if (this._closureDeallocator) return this._closureDeallocator;
 
         const features = this.exports.swjs_library_features();
@@ -71,7 +71,7 @@ export class SwiftRuntime {
         return this._closureDeallocator;
     }
 
-    callHostFunction(host_func_id: number, args: any[]) {
+    private callHostFunction(host_func_id: number, args: any[]) {
         const argc = args.length;
         const argv = this.exports.swjs_prepare_host_function_call(argc);
         for (let index = 0; index < args.length; index++) {

--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -101,259 +101,258 @@ export class SwiftRuntime {
         return output;
     }
 
-    importObjects() {
-        return {
-            swjs_set_prop: (
-                ref: ref,
-                name: ref,
-                kind: JavaScriptValueKind,
-                payload1: number,
-                payload2: number
-            ) => {
-                const obj = this.memory.getObject(ref);
-                Reflect.set(
+    /** @deprecated Use `wasmImports` instead */
+    importObjects = () => this.wasmImports;
+
+    readonly wasmImports = {
+        swjs_set_prop: (
+            ref: ref,
+            name: ref,
+            kind: JavaScriptValueKind,
+            payload1: number,
+            payload2: number
+        ) => {
+            const obj = this.memory.getObject(ref);
+            Reflect.set(
+                obj,
+                this.memory.getObject(name),
+                decodeJSValue(kind, payload1, payload2, this.memory)
+            );
+        },
+
+        swjs_get_prop: (
+            ref: ref,
+            name: ref,
+            kind_ptr: pointer,
+            payload1_ptr: pointer,
+            payload2_ptr: pointer
+        ) => {
+            const obj = this.memory.getObject(ref);
+            const result = Reflect.get(obj, this.memory.getObject(name));
+            writeJSValue(
+                result,
+                kind_ptr,
+                payload1_ptr,
+                payload2_ptr,
+                false,
+                this.memory
+            );
+        },
+
+        swjs_set_subscript: (
+            ref: ref,
+            index: number,
+            kind: JavaScriptValueKind,
+            payload1: number,
+            payload2: number
+        ) => {
+            const obj = this.memory.getObject(ref);
+            Reflect.set(
+                obj,
+                index,
+                decodeJSValue(kind, payload1, payload2, this.memory)
+            );
+        },
+
+        swjs_get_subscript: (
+            ref: ref,
+            index: number,
+            kind_ptr: pointer,
+            payload1_ptr: pointer,
+            payload2_ptr: pointer
+        ) => {
+            const obj = this.memory.getObject(ref);
+            const result = Reflect.get(obj, index);
+            writeJSValue(
+                result,
+                kind_ptr,
+                payload1_ptr,
+                payload2_ptr,
+                false,
+                this.memory
+            );
+        },
+
+        swjs_encode_string: (ref: ref, bytes_ptr_result: pointer) => {
+            const bytes = this.textEncoder.encode(this.memory.getObject(ref));
+            const bytes_ptr = this.memory.retain(bytes);
+            this.memory.writeUint32(bytes_ptr_result, bytes_ptr);
+            return bytes.length;
+        },
+
+        swjs_decode_string: (bytes_ptr: pointer, length: number) => {
+            const bytes = this.memory.bytes.subarray(
+                bytes_ptr,
+                bytes_ptr + length
+            );
+            const string = this.textDecoder.decode(bytes);
+            return this.memory.retain(string);
+        },
+
+        swjs_load_string: (ref: ref, buffer: pointer) => {
+            const bytes = this.memory.getObject(ref);
+            this.memory.writeBytes(buffer, bytes);
+        },
+
+        _swjs_call_function: (
+            ref: ref,
+            argv: pointer,
+            argc: number,
+            kind_ptr: pointer,
+            payload1_ptr: pointer,
+            payload2_ptr: pointer
+        ) => {
+            const func = this.memory.getObject(ref);
+            let result: any;
+            try {
+                result = Reflect.apply(
+                    func,
+                    undefined,
+                    decodeJSValueArray(argv, argc, this.memory)
+                );
+            } catch (error) {
+                writeJSValue(
+                    error,
+                    kind_ptr,
+                    payload1_ptr,
+                    payload2_ptr,
+                    true,
+                    this.memory
+                );
+                return;
+            }
+            writeJSValue(
+                result,
+                kind_ptr,
+                payload1_ptr,
+                payload2_ptr,
+                false,
+                this.memory
+            );
+        },
+        get swjs_call_function() {
+            return this._swjs_call_function;
+        },
+        set swjs_call_function(value) {
+            this._swjs_call_function = value;
+        },
+
+        swjs_call_function_with_this: (
+            obj_ref: ref,
+            func_ref: ref,
+            argv: pointer,
+            argc: number,
+            kind_ptr: pointer,
+            payload1_ptr: pointer,
+            payload2_ptr: pointer
+        ) => {
+            const obj = this.memory.getObject(obj_ref);
+            const func = this.memory.getObject(func_ref);
+            let result: any;
+            try {
+                result = Reflect.apply(
+                    func,
                     obj,
-                    this.memory.getObject(name),
-                    decodeJSValue(kind, payload1, payload2, this.memory)
+                    decodeJSValueArray(argv, argc, this.memory)
                 );
-            },
-
-            swjs_get_prop: (
-                ref: ref,
-                name: ref,
-                kind_ptr: pointer,
-                payload1_ptr: pointer,
-                payload2_ptr: pointer
-            ) => {
-                const obj = this.memory.getObject(ref);
-                const result = Reflect.get(obj, this.memory.getObject(name));
+            } catch (error) {
                 writeJSValue(
-                    result,
+                    error,
                     kind_ptr,
                     payload1_ptr,
                     payload2_ptr,
-                    false,
+                    true,
                     this.memory
                 );
-            },
+                return;
+            }
+            writeJSValue(
+                result,
+                kind_ptr,
+                payload1_ptr,
+                payload2_ptr,
+                false,
+                this.memory
+            );
+        },
+        swjs_call_new: (ref: ref, argv: pointer, argc: number) => {
+            const constructor = this.memory.getObject(ref);
+            const instance = Reflect.construct(
+                constructor,
+                decodeJSValueArray(argv, argc, this.memory)
+            );
+            return this.memory.retain(instance);
+        },
 
-            swjs_set_subscript: (
-                ref: ref,
-                index: number,
-                kind: JavaScriptValueKind,
-                payload1: number,
-                payload2: number
-            ) => {
-                const obj = this.memory.getObject(ref);
-                Reflect.set(
-                    obj,
-                    index,
-                    decodeJSValue(kind, payload1, payload2, this.memory)
-                );
-            },
-
-            swjs_get_subscript: (
-                ref: ref,
-                index: number,
-                kind_ptr: pointer,
-                payload1_ptr: pointer,
-                payload2_ptr: pointer
-            ) => {
-                const obj = this.memory.getObject(ref);
-                const result = Reflect.get(obj, index);
-                writeJSValue(
-                    result,
-                    kind_ptr,
-                    payload1_ptr,
-                    payload2_ptr,
-                    false,
-                    this.memory
-                );
-            },
-
-            swjs_encode_string: (ref: ref, bytes_ptr_result: pointer) => {
-                const bytes = this.textEncoder.encode(
-                    this.memory.getObject(ref)
-                );
-                const bytes_ptr = this.memory.retain(bytes);
-                this.memory.writeUint32(bytes_ptr_result, bytes_ptr);
-                return bytes.length;
-            },
-
-            swjs_decode_string: (bytes_ptr: pointer, length: number) => {
-                const bytes = this.memory.bytes.subarray(
-                    bytes_ptr,
-                    bytes_ptr + length
-                );
-                const string = this.textDecoder.decode(bytes);
-                return this.memory.retain(string);
-            },
-
-            swjs_load_string: (ref: ref, buffer: pointer) => {
-                const bytes = this.memory.getObject(ref);
-                this.memory.writeBytes(buffer, bytes);
-            },
-
-            _swjs_call_function: (
-                ref: ref,
-                argv: pointer,
-                argc: number,
-                kind_ptr: pointer,
-                payload1_ptr: pointer,
-                payload2_ptr: pointer
-            ) => {
-                const func = this.memory.getObject(ref);
-                let result: any;
-                try {
-                    result = Reflect.apply(
-                        func,
-                        undefined,
-                        decodeJSValueArray(argv, argc, this.memory)
-                    );
-                } catch (error) {
-                    writeJSValue(
-                        error,
-                        kind_ptr,
-                        payload1_ptr,
-                        payload2_ptr,
-                        true,
-                        this.memory
-                    );
-                    return;
-                }
-                writeJSValue(
-                    result,
-                    kind_ptr,
-                    payload1_ptr,
-                    payload2_ptr,
-                    false,
-                    this.memory
-                );
-            },
-            get swjs_call_function() {
-                return this._swjs_call_function;
-            },
-            set swjs_call_function(value) {
-                this._swjs_call_function = value;
-            },
-
-            swjs_call_function_with_this: (
-                obj_ref: ref,
-                func_ref: ref,
-                argv: pointer,
-                argc: number,
-                kind_ptr: pointer,
-                payload1_ptr: pointer,
-                payload2_ptr: pointer
-            ) => {
-                const obj = this.memory.getObject(obj_ref);
-                const func = this.memory.getObject(func_ref);
-                let result: any;
-                try {
-                    result = Reflect.apply(
-                        func,
-                        obj,
-                        decodeJSValueArray(argv, argc, this.memory)
-                    );
-                } catch (error) {
-                    writeJSValue(
-                        error,
-                        kind_ptr,
-                        payload1_ptr,
-                        payload2_ptr,
-                        true,
-                        this.memory
-                    );
-                    return;
-                }
-                writeJSValue(
-                    result,
-                    kind_ptr,
-                    payload1_ptr,
-                    payload2_ptr,
-                    false,
-                    this.memory
-                );
-            },
-            swjs_call_new: (ref: ref, argv: pointer, argc: number) => {
-                const constructor = this.memory.getObject(ref);
-                const instance = Reflect.construct(
+        swjs_call_throwing_new: (
+            ref: ref,
+            argv: pointer,
+            argc: number,
+            exception_kind_ptr: pointer,
+            exception_payload1_ptr: pointer,
+            exception_payload2_ptr: pointer
+        ) => {
+            const constructor = this.memory.getObject(ref);
+            let result: any;
+            try {
+                result = Reflect.construct(
                     constructor,
                     decodeJSValueArray(argv, argc, this.memory)
                 );
-                return this.memory.retain(instance);
-            },
-
-            swjs_call_throwing_new: (
-                ref: ref,
-                argv: pointer,
-                argc: number,
-                exception_kind_ptr: pointer,
-                exception_payload1_ptr: pointer,
-                exception_payload2_ptr: pointer
-            ) => {
-                const constructor = this.memory.getObject(ref);
-                let result: any;
-                try {
-                    result = Reflect.construct(
-                        constructor,
-                        decodeJSValueArray(argv, argc, this.memory)
-                    );
-                } catch (error) {
-                    writeJSValue(
-                        error,
-                        exception_kind_ptr,
-                        exception_payload1_ptr,
-                        exception_payload2_ptr,
-                        true,
-                        this.memory
-                    );
-                    return -1;
-                }
+            } catch (error) {
                 writeJSValue(
-                    null,
+                    error,
                     exception_kind_ptr,
                     exception_payload1_ptr,
                     exception_payload2_ptr,
-                    false,
+                    true,
                     this.memory
                 );
-                return this.memory.retain(result);
-            },
+                return -1;
+            }
+            writeJSValue(
+                null,
+                exception_kind_ptr,
+                exception_payload1_ptr,
+                exception_payload2_ptr,
+                false,
+                this.memory
+            );
+            return this.memory.retain(result);
+        },
 
-            swjs_instanceof: (obj_ref: ref, constructor_ref: ref) => {
-                const obj = this.memory.getObject(obj_ref);
-                const constructor = this.memory.getObject(constructor_ref);
-                return obj instanceof constructor;
-            },
+        swjs_instanceof: (obj_ref: ref, constructor_ref: ref) => {
+            const obj = this.memory.getObject(obj_ref);
+            const constructor = this.memory.getObject(constructor_ref);
+            return obj instanceof constructor;
+        },
 
-            swjs_create_function: (host_func_id: number) => {
-                const func = (...args: any[]) =>
-                    this.callHostFunction(host_func_id, args);
-                const func_ref = this.memory.retain(func);
-                this.closureDeallocator?.track(func, func_ref);
-                return func_ref;
-            },
+        swjs_create_function: (host_func_id: number) => {
+            const func = (...args: any[]) =>
+                this.callHostFunction(host_func_id, args);
+            const func_ref = this.memory.retain(func);
+            this.closureDeallocator?.track(func, func_ref);
+            return func_ref;
+        },
 
-            swjs_create_typed_array: (
-                constructor_ref: ref,
-                elementsPtr: pointer,
-                length: number
-            ) => {
-                const ArrayType: TypedArray =
-                    this.memory.getObject(constructor_ref);
-                const array = new ArrayType(
-                    this.memory.rawMemory.buffer,
-                    elementsPtr,
-                    length
-                );
-                // Call `.slice()` to copy the memory
-                return this.memory.retain(array.slice());
-            },
+        swjs_create_typed_array: (
+            constructor_ref: ref,
+            elementsPtr: pointer,
+            length: number
+        ) => {
+            const ArrayType: TypedArray =
+                this.memory.getObject(constructor_ref);
+            const array = new ArrayType(
+                this.memory.rawMemory.buffer,
+                elementsPtr,
+                length
+            );
+            // Call `.slice()` to copy the memory
+            return this.memory.retain(array.slice());
+        },
 
-            swjs_release: (ref: ref) => {
-                this.memory.release(ref);
-            },
-        };
-    }
+        swjs_release: (ref: ref) => {
+            this.memory.release(ref);
+        },
+    };
 }

--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -1,10 +1,11 @@
 import { SwiftClosureDeallocator } from "./closure-heap";
 import {
     LibraryFeatures,
-    SwiftRuntimeExportedFunctions,
+    ExportedFunctions,
     ref,
     pointer,
     TypedArray,
+    ImportedFunctions,
 } from "./types";
 import * as JSValue from "./js-value";
 import { Memory } from "./memory";
@@ -42,7 +43,7 @@ export class SwiftRuntime {
     }
 
     private get exports() {
-        return this.instance.exports as any as SwiftRuntimeExportedFunctions;
+        return this.instance.exports as any as ExportedFunctions;
     }
 
     private get memory() {
@@ -99,7 +100,7 @@ export class SwiftRuntime {
     /** @deprecated Use `wasmImports` instead */
     importObjects = () => this.wasmImports;
 
-    readonly wasmImports = {
+    readonly wasmImports: ImportedFunctions = {
         swjs_set_prop: (
             ref: ref,
             name: ref,

--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -20,6 +20,9 @@ export class SwiftRuntime {
     private _closureDeallocator: SwiftClosureDeallocator | null;
     private version: number = 703;
 
+    private textDecoder = new TextDecoder("utf-8");
+    private textEncoder = new TextEncoder(); // Only support utf-8
+
     constructor() {
         this._instance = null;
         this._memory = null;
@@ -99,9 +102,6 @@ export class SwiftRuntime {
     }
 
     importObjects() {
-        const textDecoder = new TextDecoder("utf-8");
-        const textEncoder = new TextEncoder(); // Only support utf-8
-
         return {
             swjs_set_prop: (
                 ref: ref,
@@ -172,7 +172,9 @@ export class SwiftRuntime {
             },
 
             swjs_encode_string: (ref: ref, bytes_ptr_result: pointer) => {
-                const bytes = textEncoder.encode(this.memory.getObject(ref));
+                const bytes = this.textEncoder.encode(
+                    this.memory.getObject(ref)
+                );
                 const bytes_ptr = this.memory.retain(bytes);
                 this.memory.writeUint32(bytes_ptr_result, bytes_ptr);
                 return bytes.length;
@@ -183,7 +185,7 @@ export class SwiftRuntime {
                     bytes_ptr,
                     bytes_ptr + length
                 );
-                const string = textDecoder.decode(bytes);
+                const string = this.textDecoder.decode(bytes);
                 return this.memory.retain(string);
             },
 

--- a/Runtime/src/js-value.ts
+++ b/Runtime/src/js-value.ts
@@ -1,0 +1,130 @@
+import { Memory } from "./memory";
+import { pointer } from "./types";
+
+export enum JavaScriptValueKind {
+    Invalid = -1,
+    Boolean = 0,
+    String = 1,
+    Number = 2,
+    Object = 3,
+    Null = 4,
+    Undefined = 5,
+    Function = 6,
+}
+
+export const decodeJSValue = (
+    kind: JavaScriptValueKind,
+    payload1: number,
+    payload2: number,
+    memory: Memory
+) => {
+    switch (kind) {
+        case JavaScriptValueKind.Boolean:
+            switch (payload1) {
+                case 0:
+                    return false;
+                case 1:
+                    return true;
+            }
+        case JavaScriptValueKind.Number:
+            return payload2;
+
+        case JavaScriptValueKind.String:
+        case JavaScriptValueKind.Object:
+        case JavaScriptValueKind.Function:
+            return memory.getObject(payload1);
+
+        case JavaScriptValueKind.Null:
+            return null;
+
+        case JavaScriptValueKind.Undefined:
+            return undefined;
+
+        default:
+            throw new Error(`JSValue Type kind "${kind}" is not supported`);
+    }
+};
+
+// Note:
+// `decodeValues` assumes that the size of RawJSValue is 16.
+export const decodeJSValueArray = (
+    ptr: pointer,
+    length: number,
+    memory: Memory
+) => {
+    let result = [];
+    for (let index = 0; index < length; index++) {
+        const base = ptr + 16 * index;
+        const kind = memory.readUint32(base);
+        const payload1 = memory.readUint32(base + 4);
+        const payload2 = memory.readFloat64(base + 8);
+        result.push(decodeJSValue(kind, payload1, payload2, memory));
+    }
+    return result;
+};
+
+export const writeJSValue = (
+    value: any,
+    kind_ptr: pointer,
+    payload1_ptr: pointer,
+    payload2_ptr: pointer,
+    is_exception: boolean,
+    memory: Memory
+) => {
+    const exceptionBit = (is_exception ? 1 : 0) << 31;
+    if (value === null) {
+        memory.writeUint32(kind_ptr, exceptionBit | JavaScriptValueKind.Null);
+        return;
+    }
+    switch (typeof value) {
+        case "boolean": {
+            memory.writeUint32(
+                kind_ptr,
+                exceptionBit | JavaScriptValueKind.Boolean
+            );
+            memory.writeUint32(payload1_ptr, value ? 1 : 0);
+            break;
+        }
+        case "number": {
+            memory.writeUint32(
+                kind_ptr,
+                exceptionBit | JavaScriptValueKind.Number
+            );
+            memory.writeFloat64(payload2_ptr, value);
+            break;
+        }
+        case "string": {
+            memory.writeUint32(
+                kind_ptr,
+                exceptionBit | JavaScriptValueKind.String
+            );
+            memory.writeUint32(payload1_ptr, memory.retain(value));
+            break;
+        }
+        case "undefined": {
+            memory.writeUint32(
+                kind_ptr,
+                exceptionBit | JavaScriptValueKind.Undefined
+            );
+            break;
+        }
+        case "object": {
+            memory.writeUint32(
+                kind_ptr,
+                exceptionBit | JavaScriptValueKind.Object
+            );
+            memory.writeUint32(payload1_ptr, memory.retain(value));
+            break;
+        }
+        case "function": {
+            memory.writeUint32(
+                kind_ptr,
+                exceptionBit | JavaScriptValueKind.Function
+            );
+            memory.writeUint32(payload1_ptr, memory.retain(value));
+            break;
+        }
+        default:
+            throw new Error(`Type "${typeof value}" is not supported yet`);
+    }
+};

--- a/Runtime/src/memory.ts
+++ b/Runtime/src/memory.ts
@@ -1,0 +1,32 @@
+import { SwiftRuntimeHeap } from "./object-heap";
+import { pointer } from "./types";
+
+export class Memory {
+    readonly rawMemory: WebAssembly.Memory;
+    readonly bytes: Uint8Array;
+    readonly dataView: DataView;
+
+    private readonly heap = new SwiftRuntimeHeap();
+
+    constructor(exports: WebAssembly.Exports) {
+        this.rawMemory = exports.memory as WebAssembly.Memory;
+        this.bytes = new Uint8Array(this.rawMemory.buffer);
+        this.dataView = new DataView(this.rawMemory.buffer);
+    }
+
+    retain = (value: any) => this.heap.retain(value);
+    getObject = (ref: number) => this.heap.referenceHeap(ref);
+    release = (ref: number) => this.heap.release(ref);
+
+    writeBytes(ptr: pointer, bytes: Uint8Array) {
+        this.bytes.set(bytes, ptr);
+    }
+
+    readUint32 = (ptr: pointer) => this.dataView.getUint32(ptr, true);
+    readFloat64 = (ptr: pointer) => this.dataView.getFloat64(ptr, true);
+
+    writeUint32 = (ptr: pointer, value: number) =>
+        this.dataView.setUint32(ptr, value, true);
+    writeFloat64 = (ptr: pointer, value: number) =>
+        this.dataView.setFloat64(ptr, value);
+}

--- a/Runtime/src/memory.ts
+++ b/Runtime/src/memory.ts
@@ -27,5 +27,5 @@ export class Memory {
     writeUint32 = (ptr: pointer, value: number) =>
         this.dataView.setUint32(ptr, value, true);
     writeFloat64 = (ptr: pointer, value: number) =>
-        this.dataView.setFloat64(ptr, value);
+        this.dataView.setFloat64(ptr, value, true);
 }

--- a/Runtime/src/memory.ts
+++ b/Runtime/src/memory.ts
@@ -18,9 +18,8 @@ export class Memory {
     getObject = (ref: number) => this.heap.referenceHeap(ref);
     release = (ref: number) => this.heap.release(ref);
 
-    writeBytes(ptr: pointer, bytes: Uint8Array) {
+    writeBytes = (ptr: pointer, bytes: Uint8Array) =>
         this.bytes.set(bytes, ptr);
-    }
 
     readUint32 = (ptr: pointer) => this.dataView.getUint32(ptr, true);
     readFloat64 = (ptr: pointer) => this.dataView.getFloat64(ptr, true);

--- a/Runtime/src/object-heap.ts
+++ b/Runtime/src/object-heap.ts
@@ -1,0 +1,63 @@
+import { globalVariable } from "./find-global";
+import { ref } from "./types";
+
+type SwiftRuntimeHeapEntry = {
+    id: number;
+    rc: number;
+};
+export class SwiftRuntimeHeap {
+    private _heapValueById: Map<number, any>;
+    private _heapEntryByValue: Map<any, SwiftRuntimeHeapEntry>;
+    private _heapNextKey: number;
+
+    constructor() {
+        this._heapValueById = new Map();
+        this._heapValueById.set(0, globalVariable);
+
+        this._heapEntryByValue = new Map();
+        this._heapEntryByValue.set(globalVariable, { id: 0, rc: 1 });
+
+        // Note: 0 is preserved for global
+        this._heapNextKey = 1;
+    }
+
+    retain(value: any) {
+        const isObject = typeof value == "object";
+        const entry = this._heapEntryByValue.get(value);
+        if (isObject && entry) {
+            entry.rc++;
+            return entry.id;
+        }
+        const id = this._heapNextKey++;
+        this._heapValueById.set(id, value);
+        if (isObject) {
+            this._heapEntryByValue.set(value, { id: id, rc: 1 });
+        }
+        return id;
+    }
+
+    release(ref: ref) {
+        const value = this._heapValueById.get(ref);
+        const isObject = typeof value == "object";
+        if (isObject) {
+            const entry = this._heapEntryByValue.get(value)!;
+            entry.rc--;
+            if (entry.rc != 0) return;
+
+            this._heapEntryByValue.delete(value);
+            this._heapValueById.delete(ref);
+        } else {
+            this._heapValueById.delete(ref);
+        }
+    }
+
+    referenceHeap(ref: ref) {
+        const value = this._heapValueById.get(ref);
+        if (value === undefined) {
+            throw new ReferenceError(
+                "Attempted to read invalid reference " + ref
+            );
+        }
+        return value;
+    }
+}

--- a/Runtime/src/types.ts
+++ b/Runtime/src/types.ts
@@ -98,6 +98,7 @@ export type TypedArray =
     | Uint16ArrayConstructor
     | Int32ArrayConstructor
     | Uint32ArrayConstructor
+    // BigInt is not yet supported, see https://github.com/swiftwasm/JavaScriptKit/issues/56
     // | BigInt64ArrayConstructor
     // | BigUint64ArrayConstructor
     | Float32ArrayConstructor

--- a/Runtime/src/types.ts
+++ b/Runtime/src/types.ts
@@ -1,7 +1,3 @@
-export interface ExportedMemory {
-    buffer: any;
-}
-
 export type ref = number;
 export type pointer = number;
 
@@ -18,17 +14,6 @@ export interface SwiftRuntimeExportedFunctions {
     ): void;
 
     swjs_free_host_function(host_func_id: number): void;
-}
-
-export enum JavaScriptValueKind {
-    Invalid = -1,
-    Boolean = 0,
-    String = 1,
-    Number = 2,
-    Object = 3,
-    Null = 4,
-    Undefined = 5,
-    Function = 6,
 }
 
 export enum LibraryFeatures {

--- a/Runtime/src/types.ts
+++ b/Runtime/src/types.ts
@@ -1,7 +1,9 @@
+import * as JSValue from "./js-value";
+
 export type ref = number;
 export type pointer = number;
 
-export interface SwiftRuntimeExportedFunctions {
+export interface ExportedFunctions {
     swjs_library_version(): number;
     swjs_library_features(): number;
     swjs_prepare_host_function_call(size: number): pointer;
@@ -14,6 +16,74 @@ export interface SwiftRuntimeExportedFunctions {
     ): void;
 
     swjs_free_host_function(host_func_id: number): void;
+}
+
+export interface ImportedFunctions {
+    swjs_set_prop(
+        ref: number,
+        name: number,
+        kind: JSValue.Kind,
+        payload1: number,
+        payload2: number
+    ): void;
+    swjs_get_prop(
+        ref: number,
+        name: number,
+        kind_ptr: pointer,
+        payload1_ptr: pointer,
+        payload2_ptr: pointer
+    ): void;
+    swjs_set_subscript(
+        ref: number,
+        index: number,
+        kind: JSValue.Kind,
+        payload1: number,
+        payload2: number
+    ): void;
+    swjs_get_subscript(
+        ref: number,
+        index: number,
+        kind_ptr: pointer,
+        payload1_ptr: pointer,
+        payload2_ptr: pointer
+    ): void;
+    swjs_encode_string(ref: number, bytes_ptr_result: pointer): number;
+    swjs_decode_string(bytes_ptr: pointer, length: number): number;
+    swjs_load_string(ref: number, buffer: pointer): void;
+    swjs_call_function(
+        ref: number,
+        argv: pointer,
+        argc: number,
+        kind_ptr: pointer,
+        payload1_ptr: pointer,
+        payload2_ptr: pointer
+    ): void;
+    swjs_call_function_with_this(
+        obj_ref: ref,
+        func_ref: ref,
+        argv: pointer,
+        argc: number,
+        kind_ptr: pointer,
+        payload1_ptr: pointer,
+        payload2_ptr: pointer
+    ): void;
+    swjs_call_new(ref: number, argv: pointer, argc: number): number;
+    swjs_call_throwing_new(
+        ref: number,
+        argv: pointer,
+        argc: number,
+        exception_kind_ptr: pointer,
+        exception_payload1_ptr: pointer,
+        exception_payload2_ptr: pointer
+    ): number;
+    swjs_instanceof(obj_ref: ref, constructor_ref: ref): boolean;
+    swjs_create_function(host_func_id: number): number;
+    swjs_create_typed_array(
+        constructor_ref: ref,
+        elementsPtr: pointer,
+        length: number
+    ): number;
+    swjs_release(ref: number): void;
 }
 
 export enum LibraryFeatures {

--- a/Runtime/src/types.ts
+++ b/Runtime/src/types.ts
@@ -1,0 +1,48 @@
+export interface ExportedMemory {
+    buffer: any;
+}
+
+export type ref = number;
+export type pointer = number;
+
+export interface SwiftRuntimeExportedFunctions {
+    swjs_library_version(): number;
+    swjs_library_features(): number;
+    swjs_prepare_host_function_call(size: number): pointer;
+    swjs_cleanup_host_function_call(argv: pointer): void;
+    swjs_call_host_function(
+        host_func_id: number,
+        argv: pointer,
+        argc: number,
+        callback_func_ref: ref
+    ): void;
+
+    swjs_free_host_function(host_func_id: number): void;
+}
+
+export enum JavaScriptValueKind {
+    Invalid = -1,
+    Boolean = 0,
+    String = 1,
+    Number = 2,
+    Object = 3,
+    Null = 4,
+    Undefined = 5,
+    Function = 6,
+}
+
+export enum LibraryFeatures {
+    WeakRefs = 1 << 0,
+}
+
+export type TypedArray =
+    | Int8ArrayConstructor
+    | Uint8ArrayConstructor
+    | Int16ArrayConstructor
+    | Uint16ArrayConstructor
+    | Int32ArrayConstructor
+    | Uint32ArrayConstructor
+    // | BigInt64ArrayConstructor
+    // | BigUint64ArrayConstructor
+    | Float32ArrayConstructor
+    | Float64ArrayConstructor;

--- a/Runtime/tsconfig.json
+++ b/Runtime/tsconfig.json
@@ -1,9 +1,10 @@
 {
     "compilerOptions": {
         "declaration": true,
+        "declarationDir": "lib",
         "importHelpers": true,
         "module": "esnext",
-        "outDir": "lib",
+        "noEmit": true,
         "rootDir": "src",
         "strict": true,
         "target": "es2017",

--- a/Runtime/tsconfig.json
+++ b/Runtime/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "declaration": true,
         "importHelpers": true,
-        "module": "commonjs",
+        "module": "esnext",
         "outDir": "lib",
         "rootDir": "src",
         "strict": true,

--- a/Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift
@@ -133,6 +133,7 @@ extension UInt32: TypedArrayElement {
 }
 
 // FIXME: Support passing BigInts across the bridge
+// See https://github.com/swiftwasm/JavaScriptKit/issues/56
 //extension Int64: TypedArrayElement {
 //    public static var typedArrayClass = JSObject.global.BigInt64Array.function!
 //}

--- a/package-lock.json
+++ b/package-lock.json
@@ -188,9 +188,9 @@
       "peer": true
     },
     "node_modules/typescript": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
-      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -318,9 +318,9 @@
       "peer": true
     },
     "typescript": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
-      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,119 @@
       "version": "0.11.1",
       "license": "MIT",
       "devDependencies": {
+        "@rollup/plugin-typescript": "^8.3.0",
         "prettier": "2.5.1",
+        "rollup": "^2.63.0",
         "typescript": "^4.4.2"
+      }
+    },
+    "node_modules/@rollup/plugin-typescript": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.3.0.tgz",
+      "integrity": "sha512-I5FpSvLbtAdwJ+naznv+B4sjXZUcIvLLceYpITAn7wAP8W0wqc5noLdGIp9HGVntNhRWXctwPYrSSFQxtl0FPA==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.1.0",
+        "resolve": "^1.17.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.14.0",
+        "tslib": "*",
+        "typescript": ">=3.7.0"
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "node_modules/estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/prettier": {
@@ -24,6 +135,57 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/resolve": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
+      "integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.8.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "2.63.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.63.0.tgz",
+      "integrity": "sha512-nps0idjmD+NXl6OREfyYXMn/dar3WGcyKn+KBzPdaLecub3x/LrId0wUcthcr8oZUAcZAR8NKcfGGFlNgGL1kQ==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/typescript": {
       "version": "4.4.2",
@@ -40,11 +202,120 @@
     }
   },
   "dependencies": {
+    "@rollup/plugin-typescript": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.3.0.tgz",
+      "integrity": "sha512-I5FpSvLbtAdwJ+naznv+B4sjXZUcIvLLceYpITAn7wAP8W0wqc5noLdGIp9HGVntNhRWXctwPYrSSFQxtl0FPA==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "resolve": "^1.17.0"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "is-core-module": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
     "prettier": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
       "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true
+    },
+    "resolve": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
+      "integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.8.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
+    },
+    "rollup": {
+      "version": "2.63.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.63.0.tgz",
+      "integrity": "sha512-nps0idjmD+NXl6OREfyYXMn/dar3WGcyKn+KBzPdaLecub3x/LrId0wUcthcr8oZUAcZAR8NKcfGGFlNgGL1kQ==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
+    },
+    "tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true,
+      "peer": true
     },
     "typescript": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.11.1",
   "description": "A runtime library of JavaScriptKit which is Swift framework to interact with JavaScript through WebAssembly.",
   "main": "Runtime/lib/index.js",
+  "module": "Runtime/lib/index.mjs",
+  "types": "Runtime/lib/index.d.ts",
   "files": [
     "Runtime/lib"
   ],

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "npm run build:clean && npm run build:ts",
     "build:clean": "rm -rf Runtime/lib",
-    "build:ts": "cd Runtime; tsc -b",
+    "build:ts": "cd Runtime; rollup -c",
     "prepublishOnly": "npm run build",
     "format": "prettier --write Runtime/src"
   },
@@ -32,7 +32,9 @@
   "author": "swiftwasm",
   "license": "MIT",
   "devDependencies": {
+    "@rollup/plugin-typescript": "^8.3.0",
     "prettier": "2.5.1",
+    "rollup": "^2.63.0",
     "typescript": "^4.4.2"
   }
 }


### PR DESCRIPTION
This PR:

- splits the runtime TypeScript code up into several separate modules
- adds Rollup to compile that back into a single JS file
- uses Rollup to produce two bundles instead of one:
  - one that uses UMD to allow use with Node-style `require`, or by embedding it with a `<script>` tag and using `window.JavaScriptKit`
  - one that uses ES Modules
- refactor the codebase to use a `Memory` class that provides easy access to memory and the heap
- check for FinalizationRegistry availability in `SwiftClosureDeallocator` constructor rather than outside of it