### PR TITLE
Fix detached ArrayBuffer errors

### DIFF
--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -177,7 +177,7 @@ export class SwiftRuntime {
         },
 
         swjs_decode_string: (bytes_ptr: pointer, length: number) => {
-            const bytes = this.memory.bytes.subarray(
+            const bytes = this.memory.bytes().subarray(
                 bytes_ptr,
                 bytes_ptr + length
             );

--- a/Runtime/src/memory.ts
+++ b/Runtime/src/memory.ts
@@ -3,29 +3,27 @@ import { pointer } from "./types";
 
 export class Memory {
     readonly rawMemory: WebAssembly.Memory;
-    readonly bytes: Uint8Array;
-    readonly dataView: DataView;
 
     private readonly heap = new SwiftRuntimeHeap();
 
     constructor(exports: WebAssembly.Exports) {
         this.rawMemory = exports.memory as WebAssembly.Memory;
-        this.bytes = new Uint8Array(this.rawMemory.buffer);
-        this.dataView = new DataView(this.rawMemory.buffer);
     }
 
     retain = (value: any) => this.heap.retain(value);
     getObject = (ref: number) => this.heap.referenceHeap(ref);
     release = (ref: number) => this.heap.release(ref);
 
-    writeBytes = (ptr: pointer, bytes: Uint8Array) =>
-        this.bytes.set(bytes, ptr);
+    bytes = () => new Uint8Array(this.rawMemory.buffer);
+    dataView = () => new DataView(this.rawMemory.buffer);
 
-    readUint32 = (ptr: pointer) => this.dataView.getUint32(ptr, true);
-    readFloat64 = (ptr: pointer) => this.dataView.getFloat64(ptr, true);
+    writeBytes = (ptr: pointer, bytes: Uint8Array) => this.bytes().set(bytes, ptr);
+
+    readUint32 = (ptr: pointer) => this.dataView().getUint32(ptr, true);
+    readFloat64 = (ptr: pointer) => this.dataView().getFloat64(ptr, true);
 
     writeUint32 = (ptr: pointer, value: number) =>
-        this.dataView.setUint32(ptr, value, true);
+        this.dataView().setUint32(ptr, value, true);
     writeFloat64 = (ptr: pointer, value: number) =>
-        this.dataView.setFloat64(ptr, value, true);
+        this.dataView().setFloat64(ptr, value, true);
 }


### PR DESCRIPTION
Fixes a regression caused by #150: 
`Unhandled Promise Rejection: TypeError: Underlying ArrayBuffer has been detached from the view` (Safari)
`TypeError: Cannot perform %TypedArray%.prototype.set on a detached ArrayBuffer` (Chrome)

It's troubling our unit test don't catch this but with my limited knowledge of JS memory management I don't know how to reliably recreate it.