### PR TITLE
Improve error messages when JS code throws exceptions

### DIFF
--- a/IntegrationTests/TestSuites/Sources/PrimaryTests/UnitTestUtils.swift
+++ b/IntegrationTests/TestSuites/Sources/PrimaryTests/UnitTestUtils.swift
@@ -103,6 +103,12 @@ func expectThrow<T>(_ body: @autoclosure () throws -> T, file: StaticString = #f
     throw MessageError("Expect to throw an exception", file: file, line: line, column: column)
 }
 
+func wrapUnsafeThrowableFunction(_ body: @escaping () -> Void, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws -> Error {
+    JSObject.global.callThrowingClosure.function!(JSClosure { _ in 
+            body() 
+            return .undefined
+    })
+}
 func expectNotNil<T>(_ value: T?, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
     switch value {
     case .some: return

--- a/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
+++ b/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
@@ -700,6 +700,59 @@ try test("Exception") {
     // }
     // ```
     //
+    let globalObject1 = JSObject.global.globalObject1
+    let prop_9: JSValue = globalObject1.prop_9
+
+    // MARK: Throwing method calls
+    let error1 = try expectThrow(try prop_9.object!.throwing.func1!())
+    try expectEqual(error1 is JSValue, true)
+    let errorObject = JSError(from: error1 as! JSValue)
+    try expectNotNil(errorObject)
+
+    let error2 = try expectThrow(try prop_9.object!.throwing.func2!())
+    try expectEqual(error2 is JSValue, true)
+    let errorString = try expectString(error2 as! JSValue)
+    try expectEqual(errorString, "String Error")
+
+    let error3 = try expectThrow(try prop_9.object!.throwing.func3!())
+    try expectEqual(error3 is JSValue, true)
+    let errorNumber = try expectNumber(error3 as! JSValue)
+    try expectEqual(errorNumber, 3.0)
+
+    // MARK: Simple function calls
+    let error4 = try expectThrow(try prop_9.func1.function!.throws())
+    try expectEqual(error4 is JSValue, true)
+    let errorObject2 = JSError(from: error4 as! JSValue)
+    try expectNotNil(errorObject2)
+
+    // MARK: Throwing constructor call
+    let Animal = JSObject.global.Animal.function!
+    _ = try Animal.throws.new("Tama", 3, true)
+    let ageError = try expectThrow(try Animal.throws.new("Tama", -3, true))
+    try expectEqual(ageError is JSValue, true)
+    let errorObject3 = JSError(from: ageError as! JSValue)
+    try expectNotNil(errorObject3)
+}
+
+try test("Unhandled Exception") {
+    // ```js
+    // global.globalObject1 = {
+    //   ...
+    //   prop_9: {
+    //       func1: function () {
+    //           throw new Error();
+    //       },
+    //       func2: function () {
+    //           throw "String Error";
+    //       },
+    //       func3: function () {
+    //           throw 3.0
+    //       },
+    //   },
+    //   ...
+    // }
+    // ```
+    //
 
     let globalObject1 = JSObject.global.globalObject1
     let prop_9: JSValue = globalObject1.prop_9
@@ -719,14 +772,6 @@ try test("Exception") {
     try expectEqual(error3 is JSValue, true)
     let errorNumber = try expectNumber(error3 as! JSValue)
     try expectEqual(errorNumber, 3.0)
-
-    // MARK: Throwing constructor call
-    let Animal = JSObject.global.Animal.function!
-    _ = try Animal.throws.new("Tama", 3, true)
-    let ageError = try expectThrow(try Animal.throws.new("Tama", -3, true))
-    try expectEqual(ageError is JSValue, true)
-    let errorObject3 = JSError(from: ageError as! JSValue)
-    try expectNotNil(errorObject3)
 }
 
 /// If WebAssembly.Memory is not accessed correctly (i.e. creating a new view each time),

--- a/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
+++ b/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
@@ -705,26 +705,20 @@ try test("Exception") {
     let prop_9: JSValue = globalObject1.prop_9
 
     // MARK: Throwing method calls
-    let error1 = try expectThrow(try prop_9.object!.throwing.func1!())
+    let error1 = try wrapUnsafeThrowableFunction { _ = prop_9.object!.func1!() }
     try expectEqual(error1 is JSValue, true)
     let errorObject = JSError(from: error1 as! JSValue)
     try expectNotNil(errorObject)
 
-    let error2 = try expectThrow(try prop_9.object!.throwing.func2!())
+    let error2 = try wrapUnsafeThrowableFunction { _ = prop_9.object!.func2!() }
     try expectEqual(error2 is JSValue, true)
     let errorString = try expectString(error2 as! JSValue)
     try expectEqual(errorString, "String Error")
 
-    let error3 = try expectThrow(try prop_9.object!.throwing.func3!())
+    let error3 = try wrapUnsafeThrowableFunction { _ = prop_9.object!.func3!() }
     try expectEqual(error3 is JSValue, true)
     let errorNumber = try expectNumber(error3 as! JSValue)
     try expectEqual(errorNumber, 3.0)
-
-    // MARK: Simple function calls
-    let error4 = try expectThrow(try prop_9.func1.function!.throws())
-    try expectEqual(error4 is JSValue, true)
-    let errorObject2 = JSError(from: error4 as! JSValue)
-    try expectNotNil(errorObject2)
 
     // MARK: Throwing constructor call
     let Animal = JSObject.global.Animal.function!

--- a/IntegrationTests/bin/primary-tests.js
+++ b/IntegrationTests/bin/primary-tests.js
@@ -82,6 +82,14 @@ global.Animal = function (name, age, isCat) {
     }
 };
 
+global.callThrowingClosure = (c) => { 
+    try {
+        c() 
+    } catch (error) {
+        return error
+    }
+}
+
 const { startWasiTask } = require("../lib");
 
 startWasiTask("./dist/PrimaryTests.wasm").catch((err) => {

--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -14,7 +14,7 @@ export class SwiftRuntime {
     private _instance: WebAssembly.Instance | null;
     private _memory: Memory | null;
     private _closureDeallocator: SwiftClosureDeallocator | null;
-    private version: number = 705;
+    private version: number = 706;
 
     private textDecoder = new TextDecoder("utf-8");
     private textEncoder = new TextEncoder(); // Only support utf-8

--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -235,19 +235,34 @@ export class SwiftRuntime {
             payload2_ptr: pointer
         ) => {
             const func = this.memory.getObject(ref);
-            const result = Reflect.apply(
-                func,
-                undefined,
-                JSValue.decodeArray(argv, argc, this.memory)
-            );
-            JSValue.write(
-                result,
-                kind_ptr,
-                payload1_ptr,
-                payload2_ptr,
-                false,
-                this.memory
-            );
+            let isException = true;
+            try {
+                const result = Reflect.apply(
+                    func,
+                    undefined,
+                    JSValue.decodeArray(argv, argc, this.memory)
+                );
+                JSValue.write(
+                    result,
+                    kind_ptr,
+                    payload1_ptr,
+                    payload2_ptr,
+                    false,
+                    this.memory
+                );
+                isException = false;
+            } finally {
+                if (isException) {
+                    JSValue.write(
+                        undefined,
+                        kind_ptr,
+                        payload1_ptr,
+                        payload2_ptr,
+                        true,
+                        this.memory
+                    );
+                }
+            }
         },
 
         swjs_call_function_with_this: (

--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -315,19 +315,34 @@ export class SwiftRuntime {
         ) => {
             const obj = this.memory.getObject(obj_ref);
             const func = this.memory.getObject(func_ref);
-            const result = Reflect.apply(
-                func,
-                obj,
-                JSValue.decodeArray(argv, argc, this.memory)
-            );
-            JSValue.write(
-                result,
-                kind_ptr,
-                payload1_ptr,
-                payload2_ptr,
-                false,
-                this.memory
-            );
+            let isException = true;
+            try {
+                const result = Reflect.apply(
+                    func,
+                    obj,
+                    JSValue.decodeArray(argv, argc, this.memory)
+                );
+                JSValue.write(
+                    result,
+                    kind_ptr,
+                    payload1_ptr,
+                    payload2_ptr,
+                    false,
+                    this.memory
+                );
+                isException = false
+            } finally {
+                if (isException) {
+                    JSValue.write(
+                        undefined,
+                        kind_ptr,
+                        payload1_ptr,
+                        payload2_ptr,
+                        true,
+                        this.memory
+                    );
+                }
+            }
         },
         swjs_call_new: (ref: ref, argv: pointer, argc: number) => {
             const constructor = this.memory.getObject(ref);

--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -226,7 +226,7 @@ export class SwiftRuntime {
                 this.memory
             );
         },
-        swjs_call_function_unsafe: (
+        swjs_call_function_no_catch: (
             ref: ref,
             argv: pointer,
             argc: number,
@@ -304,7 +304,7 @@ export class SwiftRuntime {
             );
         },
 
-        swjs_call_function_with_this_unsafe: (
+        swjs_call_function_with_this_no_catch: (
             obj_ref: ref,
             func_ref: ref,
             argv: pointer,

--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -226,6 +226,29 @@ export class SwiftRuntime {
                 this.memory
             );
         },
+        swjs_call_function_unsafe: (
+            ref: ref,
+            argv: pointer,
+            argc: number,
+            kind_ptr: pointer,
+            payload1_ptr: pointer,
+            payload2_ptr: pointer
+        ) => {
+            const func = this.memory.getObject(ref);
+            const result = Reflect.apply(
+                func,
+                undefined,
+                JSValue.decodeArray(argv, argc, this.memory)
+            );
+            JSValue.write(
+                result,
+                kind_ptr,
+                payload1_ptr,
+                payload2_ptr,
+                false,
+                this.memory
+            );
+        },
 
         swjs_call_function_with_this: (
             obj_ref: ref,
@@ -256,6 +279,32 @@ export class SwiftRuntime {
                 );
                 return;
             }
+            JSValue.write(
+                result,
+                kind_ptr,
+                payload1_ptr,
+                payload2_ptr,
+                false,
+                this.memory
+            );
+        },
+
+        swjs_call_function_with_this_unsafe: (
+            obj_ref: ref,
+            func_ref: ref,
+            argv: pointer,
+            argc: number,
+            kind_ptr: pointer,
+            payload1_ptr: pointer,
+            payload2_ptr: pointer
+        ) => {
+            const obj = this.memory.getObject(obj_ref);
+            const func = this.memory.getObject(func_ref);
+            const result = Reflect.apply(
+                func,
+                obj,
+                JSValue.decodeArray(argv, argc, this.memory)
+            );
             JSValue.write(
                 result,
                 kind_ptr,

--- a/Runtime/src/types.ts
+++ b/Runtime/src/types.ts
@@ -58,7 +58,24 @@ export interface ImportedFunctions {
         payload1_ptr: pointer,
         payload2_ptr: pointer
     ): void;
+    swjs_call_function_unsafe(
+        ref: number,
+        argv: pointer,
+        argc: number,
+        kind_ptr: pointer,
+        payload1_ptr: pointer,
+        payload2_ptr: pointer
+    ): void;
     swjs_call_function_with_this(
+        obj_ref: ref,
+        func_ref: ref,
+        argv: pointer,
+        argc: number,
+        kind_ptr: pointer,
+        payload1_ptr: pointer,
+        payload2_ptr: pointer
+    ): void;
+    swjs_call_function_with_this_unsafe(
         obj_ref: ref,
         func_ref: ref,
         argv: pointer,

--- a/Runtime/src/types.ts
+++ b/Runtime/src/types.ts
@@ -58,7 +58,7 @@ export interface ImportedFunctions {
         payload1_ptr: pointer,
         payload2_ptr: pointer
     ): void;
-    swjs_call_function_unsafe(
+    swjs_call_function_no_catch(
         ref: number,
         argv: pointer,
         argc: number,
@@ -75,7 +75,7 @@ export interface ImportedFunctions {
         payload1_ptr: pointer,
         payload2_ptr: pointer
     ): void;
-    swjs_call_function_with_this_unsafe(
+    swjs_call_function_with_this_no_catch(
         obj_ref: ref,
         func_ref: ref,
         argv: pointer,

--- a/Sources/JavaScriptKit/FundamentalObjects/JSFunction.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSFunction.swift
@@ -93,11 +93,11 @@ internal func invokeJSFunction(_ jsFunc: JSFunction, arguments: [ConvertibleToJS
             var payload1 = JavaScriptPayload1()
             var payload2 = JavaScriptPayload2()
             if let thisId = this?.id {
-                _call_function_with_this(thisId,
+                _call_function_with_this_unsafe(thisId,
                                          jsFunc.id, argv, Int32(argc),
                                          &kindAndFlags, &payload1, &payload2)
             } else {
-                _call_function(
+                _call_function_unsafe(
                     jsFunc.id, argv, Int32(argc),
                     &kindAndFlags, &payload1, &payload2
                 )

--- a/Sources/JavaScriptKit/FundamentalObjects/JSFunction.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSFunction.swift
@@ -19,7 +19,7 @@ public class JSFunction: JSObject {
     /// - Returns: The result of this call.
     @discardableResult
     public func callAsFunction(this: JSObject? = nil, arguments: [ConvertibleToJSValue]) -> JSValue {
-        try! invokeJSFunction(self, arguments: arguments, this: this)
+        try! invokeNonThrowingJSFunction(self, arguments: arguments, this: this)
     }
 
     /// A variadic arguments version of `callAsFunction`.
@@ -84,7 +84,7 @@ public class JSFunction: JSObject {
     }
 }
 
-internal func invokeJSFunction(_ jsFunc: JSFunction, arguments: [ConvertibleToJSValue], this: JSObject?) throws -> JSValue {
+private func invokeNonThrowingJSFunction(_ jsFunc: JSFunction, arguments: [ConvertibleToJSValue], this: JSObject?) throws -> JSValue {
     let (result, isException) = arguments.withRawJSValues { rawValues in
         rawValues.withUnsafeBufferPointer { bufferPointer -> (JSValue, Bool) in
             let argv = bufferPointer.baseAddress
@@ -102,6 +102,7 @@ internal func invokeJSFunction(_ jsFunc: JSFunction, arguments: [ConvertibleToJS
                     &kindAndFlags, &payload1, &payload2
                 )
             }
+            assert(!kindAndFlags.isException)
             let result = RawJSValue(kind: kindAndFlags.kind, payload1: payload1, payload2: payload2)
             return (result.jsValue(), kindAndFlags.isException)
         }

--- a/Sources/JavaScriptKit/XcodeSupport.swift
+++ b/Sources/JavaScriptKit/XcodeSupport.swift
@@ -53,7 +53,22 @@ import _CJavaScriptKit
         _: UnsafeMutablePointer<JavaScriptPayload1>!,
         _: UnsafeMutablePointer<JavaScriptPayload2>!
     ) { fatalError() }
+    func _call_function_unsafe(
+        _: JavaScriptObjectRef,
+        _: UnsafePointer<RawJSValue>!, _: Int32,
+        _: UnsafeMutablePointer<JavaScriptValueKindAndFlags>!,
+        _: UnsafeMutablePointer<JavaScriptPayload1>!,
+        _: UnsafeMutablePointer<JavaScriptPayload2>!
+    ) { fatalError() }
     func _call_function_with_this(
+        _: JavaScriptObjectRef,
+        _: JavaScriptObjectRef,
+        _: UnsafePointer<RawJSValue>!, _: Int32,
+        _: UnsafeMutablePointer<JavaScriptValueKindAndFlags>!,
+        _: UnsafeMutablePointer<JavaScriptPayload1>!,
+        _: UnsafeMutablePointer<JavaScriptPayload2>!
+    ) { fatalError() }
+    func _call_function_with_this_unsafe(
         _: JavaScriptObjectRef,
         _: JavaScriptObjectRef,
         _: UnsafePointer<RawJSValue>!, _: Int32,

--- a/Sources/JavaScriptKit/XcodeSupport.swift
+++ b/Sources/JavaScriptKit/XcodeSupport.swift
@@ -53,7 +53,7 @@ import _CJavaScriptKit
         _: UnsafeMutablePointer<JavaScriptPayload1>!,
         _: UnsafeMutablePointer<JavaScriptPayload2>!
     ) { fatalError() }
-    func _call_function_unsafe(
+    func _call_function_no_catch(
         _: JavaScriptObjectRef,
         _: UnsafePointer<RawJSValue>!, _: Int32,
         _: UnsafeMutablePointer<JavaScriptValueKindAndFlags>!,
@@ -68,7 +68,7 @@ import _CJavaScriptKit
         _: UnsafeMutablePointer<JavaScriptPayload1>!,
         _: UnsafeMutablePointer<JavaScriptPayload2>!
     ) { fatalError() }
-    func _call_function_with_this_unsafe(
+    func _call_function_with_this_no_catch(
         _: JavaScriptObjectRef,
         _: JavaScriptObjectRef,
         _: UnsafePointer<RawJSValue>!, _: Int32,

--- a/Sources/_CJavaScriptKit/_CJavaScriptKit.c
+++ b/Sources/_CJavaScriptKit/_CJavaScriptKit.c
@@ -36,7 +36,7 @@ void swjs_cleanup_host_function_call(void *argv_buffer) {
 /// this and `SwiftRuntime.version` in `./Runtime/src/index.ts`.
 __attribute__((export_name("swjs_library_version")))
 int swjs_library_version(void) {
-    return 705;
+    return 706;
 }
 
 int _library_features(void);

--- a/Sources/_CJavaScriptKit/include/_CJavaScriptKit.h
+++ b/Sources/_CJavaScriptKit/include/_CJavaScriptKit.h
@@ -170,6 +170,21 @@ extern void _call_function(const JavaScriptObjectRef ref, const RawJSValue *argv
                            JavaScriptPayload1 *result_payload1,
                            JavaScriptPayload2 *result_payload2);
 
+/// `_call_function` calls JavaScript function with given arguments list without capturing any exception
+///
+/// @param ref The target JavaScript function to call.
+/// @param argv A list of `RawJSValue` arguments to apply.
+/// @param argc The length of `argv``.
+/// @param result_kind A result pointer of JavaScript value kind of returned result or thrown exception.
+/// @param result_payload1 A result pointer of first payload of JavaScript value of returned result or thrown exception.
+/// @param result_payload2 A result pointer of second payload of JavaScript value of returned result or thrown exception.
+__attribute__((__import_module__("javascript_kit"),
+               __import_name__("swjs_call_function_unsafe")))
+extern void _call_function_unsafe(const JavaScriptObjectRef ref, const RawJSValue *argv,
+                           const int argc, JavaScriptValueKindAndFlags *result_kind,
+                           JavaScriptPayload1 *result_payload1,
+                           JavaScriptPayload2 *result_payload2);
+
 /// `_call_function_with_this` calls JavaScript function with given arguments list and given `_this`.
 ///
 /// @param _this The value of `this` provided for the call to `func_ref`.
@@ -182,6 +197,24 @@ extern void _call_function(const JavaScriptObjectRef ref, const RawJSValue *argv
 __attribute__((__import_module__("javascript_kit"),
                __import_name__("swjs_call_function_with_this")))
 extern void _call_function_with_this(const JavaScriptObjectRef _this,
+                                     const JavaScriptObjectRef func_ref,
+                                     const RawJSValue *argv, const int argc,
+                                     JavaScriptValueKindAndFlags *result_kind,
+                                     JavaScriptPayload1 *result_payload1,
+                                     JavaScriptPayload2 *result_payload2);
+
+/// `_call_function_with_this` calls JavaScript function with given arguments list and given `_this` without capturing any exception.
+///
+/// @param _this The value of `this` provided for the call to `func_ref`.
+/// @param func_ref The target JavaScript function to call.
+/// @param argv A list of `RawJSValue` arguments to apply.
+/// @param argc The length of `argv``.
+/// @param result_kind A result pointer of JavaScript value kind of returned result or thrown exception.
+/// @param result_payload1 A result pointer of first payload of JavaScript value of returned result or thrown exception.
+/// @param result_payload2 A result pointer of second payload of JavaScript value of returned result or thrown exception.
+__attribute__((__import_module__("javascript_kit"),
+               __import_name__("swjs_call_function_with_this_unsafe")))
+extern void _call_function_with_this_unsafe(const JavaScriptObjectRef _this,
                                      const JavaScriptObjectRef func_ref,
                                      const RawJSValue *argv, const int argc,
                                      JavaScriptValueKindAndFlags *result_kind,

--- a/Sources/_CJavaScriptKit/include/_CJavaScriptKit.h
+++ b/Sources/_CJavaScriptKit/include/_CJavaScriptKit.h
@@ -179,8 +179,8 @@ extern void _call_function(const JavaScriptObjectRef ref, const RawJSValue *argv
 /// @param result_payload1 A result pointer of first payload of JavaScript value of returned result or thrown exception.
 /// @param result_payload2 A result pointer of second payload of JavaScript value of returned result or thrown exception.
 __attribute__((__import_module__("javascript_kit"),
-               __import_name__("swjs_call_function_unsafe")))
-extern void _call_function_unsafe(const JavaScriptObjectRef ref, const RawJSValue *argv,
+               __import_name__("swjs_call_function_no_catch")))
+extern void _call_function_no_catch(const JavaScriptObjectRef ref, const RawJSValue *argv,
                            const int argc, JavaScriptValueKindAndFlags *result_kind,
                            JavaScriptPayload1 *result_payload1,
                            JavaScriptPayload2 *result_payload2);
@@ -213,8 +213,8 @@ extern void _call_function_with_this(const JavaScriptObjectRef _this,
 /// @param result_payload1 A result pointer of first payload of JavaScript value of returned result or thrown exception.
 /// @param result_payload2 A result pointer of second payload of JavaScript value of returned result or thrown exception.
 __attribute__((__import_module__("javascript_kit"),
-               __import_name__("swjs_call_function_with_this_unsafe")))
-extern void _call_function_with_this_unsafe(const JavaScriptObjectRef _this,
+               __import_name__("swjs_call_function_with_this_no_catch")))
+extern void _call_function_with_this_no_catch(const JavaScriptObjectRef _this,
                                      const JavaScriptObjectRef func_ref,
                                      const RawJSValue *argv, const int argc,
                                      JavaScriptValueKindAndFlags *result_kind,


### PR DESCRIPTION
We've noticed when JS code throws an exception evaluated from ``JSFunction`` the error reported shows this message:

```
RuntimeError: Unreachable code should not be executed (evaluating 'this.exports.swjs_call_host_function(e,a,r,u)')
  [native code] at line 0
   ../node_modules/javascript-kit-swift/Runtime/lib/index.mjs at line 348
```

After reviewing this with the team, @kateinoigakukun suggested there where a try/catch capturing the exception we should remove in order to improve this scenario. 

This PR adds two new unsafe versions of already existing functions where the JS side of the project doesn't capture any exception so the final result is a better error reporting like this:

<img width="1323" alt="Screen_Shot_2022-03-30_at_10 35 52" src="https://user-images.githubusercontent.com/4030704/160869821-99193ad3-7fff-4b12-9cb0-08a8aba678bd.png">

