### PR TITLE
Cleanup & improvements to perf-tester

### DIFF
--- a/ci/perf-tester/src/index.js
+++ b/ci/perf-tester/src/index.js
@@ -31,8 +31,8 @@ const {
     diffTable,
 } = require("./utils.js");
 
-const benchmarkParallel = 2;
-const benchmarkSerial = 2;
+const benchmarkParallel = 4;
+const benchmarkSerial = 4;
 const runBenchmarks = async () => {
     let results = [];
     for (let i = 0; i < benchmarkSerial; i++) {

--- a/ci/perf-tester/src/index.js
+++ b/ci/perf-tester/src/index.js
@@ -136,7 +136,7 @@ async function run(octokit, context, token) {
         body: markdownDiff,
     };
 
-    if (toBool(getInput("use-check"))) {
+    // if (toBool(getInput("use-check"))) {
         if (token) {
             const finish = await createCheck(octokit, context);
             await finish({
@@ -149,7 +149,7 @@ async function run(octokit, context, token) {
         } else {
             outputRawMarkdown = true;
         }
-    } else {
+    // } else {
         startGroup(`Updating stats PR comment`);
         let commentId;
         try {
@@ -205,7 +205,7 @@ async function run(octokit, context, token) {
                     outputRawMarkdown = true;
                 }
             }
-        }
+        // }
         endGroup();
     }
 

--- a/ci/perf-tester/src/index.js
+++ b/ci/perf-tester/src/index.js
@@ -24,7 +24,7 @@ const { setFailed, startGroup, endGroup, debug } = require("@actions/core");
 const { GitHub, context } = require("@actions/github");
 const { exec } = require("@actions/exec");
 const {
-    getInput,
+    config,
     runBenchmark,
     averageBenchmarks,
     toDiff,
@@ -63,9 +63,8 @@ async function run(octokit, context) {
         `PR #${pull_number} is targetted at ${pr.base.ref} (${pr.base.sha})`
     );
 
-    const buildScript = getInput("build-script");
-    startGroup(`[current] Build using '${buildScript}'`);
-    await exec(buildScript);
+    startGroup(`[current] Build using '${config.buildScript}'`);
+    await exec(config.buildScript);
     endGroup();
 
     startGroup(`[current] Running benchmark`);
@@ -106,8 +105,8 @@ async function run(octokit, context) {
     }
     endGroup();
 
-    startGroup(`[base] Build using '${buildScript}'`);
-    await exec(buildScript);
+    startGroup(`[base] Build using '${config.buildScript}'`);
+    await exec(config.buildScript);
     endGroup();
 
     startGroup(`[base] Running benchmark`);
@@ -120,10 +119,7 @@ async function run(octokit, context) {
         collapseUnchanged: true,
         omitUnchanged: false,
         showTotal: true,
-        minimumChangeThreshold: parseInt(
-            getInput("minimum-change-threshold"),
-            10
-        ),
+        minimumChangeThreshold: config.minimumChangeThreshold,
     });
 
     let outputRawMarkdown = false;
@@ -208,8 +204,7 @@ async function run(octokit, context) {
 
 (async () => {
     try {
-        const token = getInput("repo-token", { required: true });
-        const octokit = new GitHub(token);
+        const octokit = new GitHub(process.env.GITHUB_TOKEN);
         await run(octokit, context);
     } catch (e) {
         setFailed(e.message);

--- a/ci/perf-tester/src/index.js
+++ b/ci/perf-tester/src/index.js
@@ -29,7 +29,6 @@ const {
     averageBenchmarks,
     toDiff,
     diffTable,
-    toBool,
 } = require("./utils.js");
 
 const benchmarkParallel = 2;
@@ -44,7 +43,7 @@ const runBenchmarks = async () => {
     return averageBenchmarks(results);
 };
 
-async function run(octokit, context, token) {
+async function run(octokit, context) {
     const { number: pull_number } = context.issue;
 
     const pr = context.payload.pull_request;
@@ -136,76 +135,60 @@ async function run(octokit, context, token) {
         body: markdownDiff,
     };
 
-    // if (toBool(getInput("use-check"))) {
-        if (token) {
-            const finish = await createCheck(octokit, context);
-            await finish({
-                conclusion: "success",
-                output: {
-                    title: `Compressed Size Action`,
-                    summary: markdownDiff,
-                },
-            });
-        } else {
-            outputRawMarkdown = true;
-        }
-    // } else {
-        startGroup(`Updating stats PR comment`);
-        let commentId;
-        try {
-            const comments = (await octokit.issues.listComments(commentInfo))
-                .data;
-            for (let i = comments.length; i--; ) {
-                const c = comments[i];
-                if (
-                    c.user.type === "Bot" &&
-                    /<sub>[\s\n]*performance-action/.test(c.body)
-                ) {
-                    commentId = c.id;
-                    break;
-                }
+    startGroup(`Updating stats PR comment`);
+    let commentId;
+    try {
+        const comments = (await octokit.issues.listComments(commentInfo)).data;
+        for (let i = comments.length; i--; ) {
+            const c = comments[i];
+            if (
+                c.user.type === "Bot" &&
+                /<sub>[\s\n]*performance-action/.test(c.body)
+            ) {
+                commentId = c.id;
+                break;
             }
-        } catch (e) {
-            console.log("Error checking for previous comments: " + e.message);
         }
+    } catch (e) {
+        console.log("Error checking for previous comments: " + e.message);
+    }
 
-        if (commentId) {
-            console.log(`Updating previous comment #${commentId}`);
+    if (commentId) {
+        console.log(`Updating previous comment #${commentId}`);
+        try {
+            await octokit.issues.updateComment({
+                ...context.repo,
+                comment_id: commentId,
+                body: comment.body,
+            });
+        } catch (e) {
+            console.log("Error editing previous comment: " + e.message);
+            commentId = null;
+        }
+    }
+
+    // no previous or edit failed
+    if (!commentId) {
+        console.log("Creating new comment");
+        try {
+            await octokit.issues.createComment(comment);
+        } catch (e) {
+            console.log(`Error creating comment: ${e.message}`);
+            console.log(`Submitting a PR review comment instead...`);
             try {
-                await octokit.issues.updateComment({
-                    ...context.repo,
-                    comment_id: commentId,
+                const issue = context.issue || pr;
+                await octokit.pulls.createReview({
+                    owner: issue.owner,
+                    repo: issue.repo,
+                    pull_number: issue.number,
+                    event: "COMMENT",
                     body: comment.body,
                 });
             } catch (e) {
-                console.log("Error editing previous comment: " + e.message);
-                commentId = null;
+                console.log("Error creating PR review.");
+                outputRawMarkdown = true;
             }
         }
-
-        // no previous or edit failed
-        if (!commentId) {
-            console.log("Creating new comment");
-            try {
-                await octokit.issues.createComment(comment);
-            } catch (e) {
-                console.log(`Error creating comment: ${e.message}`);
-                console.log(`Submitting a PR review comment instead...`);
-                try {
-                    const issue = context.issue || pr;
-                    await octokit.pulls.createReview({
-                        owner: issue.owner,
-                        repo: issue.repo,
-                        pull_number: issue.number,
-                        event: "COMMENT",
-                        body: comment.body,
-                    });
-                } catch (e) {
-                    console.log("Error creating PR review.");
-                    outputRawMarkdown = true;
-                }
-            }
-        // }
         endGroup();
     }
 
@@ -223,31 +206,11 @@ async function run(octokit, context, token) {
     console.log("All done!");
 }
 
-// create a check and return a function that updates (completes) it
-async function createCheck(octokit, context) {
-    const check = await octokit.checks.create({
-        ...context.repo,
-        name: "Compressed Size",
-        head_sha: context.payload.pull_request.head.sha,
-        status: "in_progress",
-    });
-
-    return async (details) => {
-        await octokit.checks.update({
-            ...context.repo,
-            check_run_id: check.data.id,
-            completed_at: new Date().toISOString(),
-            status: "completed",
-            ...details,
-        });
-    };
-}
-
 (async () => {
     try {
         const token = getInput("repo-token", { required: true });
         const octokit = new GitHub(token);
-        await run(octokit, context, token);
+        await run(octokit, context);
     } catch (e) {
         setFailed(e.message);
     }

--- a/ci/perf-tester/src/index.js
+++ b/ci/perf-tester/src/index.js
@@ -133,9 +133,7 @@ async function run(octokit, context, token) {
 
     const comment = {
         ...commentInfo,
-        body:
-            markdownDiff +
-            '\n\n<a href="https://github.com/j-f1/performance-action"><sub>performance-action</sub></a>',
+        body: markdownDiff,
     };
 
     if (toBool(getInput("use-check"))) {

--- a/ci/perf-tester/src/index.js
+++ b/ci/perf-tester/src/index.js
@@ -43,6 +43,9 @@ const runBenchmarks = async () => {
     return averageBenchmarks(results);
 };
 
+const perfActionComment =
+    "<!-- this-is-an-automated-performance-comment-do-not-edit -->";
+
 async function run(octokit, context) {
     const { number: pull_number } = context.issue;
 
@@ -132,7 +135,7 @@ async function run(octokit, context) {
 
     const comment = {
         ...commentInfo,
-        body: markdownDiff,
+        body: markdownDiff + "\n\n" + perfActionComment,
     };
 
     startGroup(`Updating stats PR comment`);
@@ -141,10 +144,7 @@ async function run(octokit, context) {
         const comments = (await octokit.issues.listComments(commentInfo)).data;
         for (let i = comments.length; i--; ) {
             const c = comments[i];
-            if (
-                c.user.type === "Bot" &&
-                /<sub>[\s\n]*performance-action/.test(c.body)
-            ) {
+            if (c.user.type === "Bot" && c.body.includes(perfActionComment)) {
                 commentId = c.id;
                 break;
             }

--- a/ci/perf-tester/src/utils.js
+++ b/ci/perf-tester/src/utils.js
@@ -27,19 +27,16 @@ const formatMS = (ms) =>
         maximumFractionDigits: 0,
     })}ms`;
 
-const getInput = (key) =>
-    ({
-        "build-script": "make bootstrap benchmark_setup",
-        benchmark: "make -s run_benchmark",
-        "minimum-change-threshold": 5,
-        "use-check": "no",
-        "repo-token": process.env.GITHUB_TOKEN,
-    }[key]);
-exports.getInput = getInput;
+const config = {
+    buildScript: "make bootstrap benchmark_setup",
+    benchmark: "make -s run_benchmark",
+    minimumChangeThreshold: 5,
+};
+exports.config = config;
 
 exports.runBenchmark = async () => {
     let benchmarkBuffers = [];
-    await exec(getInput("benchmark"), [], {
+    await exec(config.benchmark, [], {
         listeners: {
             stdout: (data) => benchmarkBuffers.push(data),
         },

--- a/ci/perf-tester/src/utils.js
+++ b/ci/perf-tester/src/utils.js
@@ -213,9 +213,3 @@ exports.diffTable = (
 
     return out;
 };
-
-/**
- * Convert a string "true"/"yes"/"1" argument value to a boolean
- * @param {string} v
- */
-exports.toBool = (v) => /^(1|true|yes)$/.test(v);

--- a/ci/perf-tester/src/utils.js
+++ b/ci/perf-tester/src/utils.js
@@ -20,8 +20,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-const fs = require("fs");
 const { exec } = require("@actions/exec");
+
+const formatMS = (ms) =>
+    `${ms.toLocaleString("en-US", {
+        maximumFractionDigits: 0,
+    })}ms`;
 
 const getInput = (key) =>
     ({
@@ -88,8 +92,7 @@ exports.toDiff = (before, after) => {
  * @param {number} difference
  */
 function getDeltaText(delta, difference) {
-    let deltaText =
-        (delta > 0 ? "+" : "") + delta.toLocaleString("en-US") + "ms";
+    let deltaText = (delta > 0 ? "+" : "") + formatMS(delta);
     if (delta && Math.abs(delta) > 1) {
         deltaText += ` (${Math.abs(difference)}%)`;
     }
@@ -183,7 +186,7 @@ exports.diffTable = (
 
         const columns = [
             name,
-            time.toLocaleString("en-US") + "ms",
+            formatMS(time),
             getDeltaText(delta, difference),
             iconForDifference(difference),
         ];
@@ -198,16 +201,14 @@ exports.diffTable = (
 
     if (unChangedRows.length !== 0) {
         const outUnchanged = markdownTable(unChangedRows);
-        out += `\n\n<details><summary>ℹ️ <strong>View Unchanged</strong></summary>\n\n${outUnchanged}\n\n</details>\n\n`;
+        out += `\n\n<details><summary><strong>View Unchanged</strong></summary>\n\n${outUnchanged}\n\n</details>\n\n`;
     }
 
     if (showTotal) {
         const totalDifference = ((totalDelta / totalTime) * 100) | 0;
         let totalDeltaText = getDeltaText(totalDelta, totalDifference);
         let totalIcon = iconForDifference(totalDifference);
-        out = `**Total Time:** ${totalTime.toLocaleString(
-            "en-US"
-        )}ms\n\n${out}`;
+        out = `**Total Time:** ${formatMS(totalTime)}\n\n${out}`;
         out = `**Time Change:** ${totalDeltaText} ${totalIcon}\n\n${out}`;
     }
 


### PR DESCRIPTION
- clean up the code to remove unnecessary configuration options and other cruft from the original action
- quadruple the number of total benchmark runs, hopefully reducing the amount of noise regularly seen in benchmark runs
- remove false precision in the reported numbers
- tweak the automatic comment slightly