### PR TITLE
Add diagnostics for those who build with WASI command line ABI

### DIFF
--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -27,6 +27,14 @@ export class SwiftRuntime {
 
     setInstance(instance: WebAssembly.Instance) {
         this._instance = instance;
+        if (typeof (this.exports as any)._start === "function") {
+            throw new Error(
+                `JavaScriptKit supports only WASI reactor ABI.
+                Please make sure you are building with:
+                -Xswiftc -Xclang-linker -Xswiftc -mexec-model=reactor
+                `
+            );
+        }
         if (this.exports.swjs_library_version() != this.version) {
             throw new Error(
                 `The versions of JavaScriptKit are incompatible.

--- a/Sources/JavaScriptKit/Runtime/index.js
+++ b/Sources/JavaScriptKit/Runtime/index.js
@@ -365,6 +365,12 @@
         }
         setInstance(instance) {
             this._instance = instance;
+            if (typeof this.exports._start === "function") {
+                throw new Error(`JavaScriptKit supports only WASI reactor ABI.
+                Please make sure you are building with:
+                -Xswiftc -Xclang-linker -Xswiftc -mexec-model=reactor
+                `);
+            }
             if (this.exports.swjs_library_version() != this.version) {
                 throw new Error(`The versions of JavaScriptKit are incompatible.
                 WebAssembly runtime ${this.exports.swjs_library_version()} != JS runtime ${this.version}`);

--- a/Sources/JavaScriptKit/Runtime/index.mjs
+++ b/Sources/JavaScriptKit/Runtime/index.mjs
@@ -359,6 +359,12 @@ class SwiftRuntime {
     }
     setInstance(instance) {
         this._instance = instance;
+        if (typeof this.exports._start === "function") {
+            throw new Error(`JavaScriptKit supports only WASI reactor ABI.
+                Please make sure you are building with:
+                -Xswiftc -Xclang-linker -Xswiftc -mexec-model=reactor
+                `);
+        }
         if (this.exports.swjs_library_version() != this.version) {
             throw new Error(`The versions of JavaScriptKit are incompatible.
                 WebAssembly runtime ${this.exports.swjs_library_version()} != JS runtime ${this.version}`);


### PR DESCRIPTION
It's hard to find the root cause of crash when building with WASI command ABI

Mitigate unfortunate situations like https://github.com/swiftwasm/JavaScriptKit/issues/199