### PR TITLE
Refine benchmark suite

### DIFF
--- a/IntegrationTests/TestSuites/Package.swift
+++ b/IntegrationTests/TestSuites/Package.swift
@@ -35,6 +35,6 @@ let package = Package(
                 .product(name: "JavaScriptEventLoop", package: "JavaScriptKit"),
             ]
         ),
-        .target(name: "BenchmarkTests", dependencies: ["JavaScriptKit"]),
+        .target(name: "BenchmarkTests", dependencies: ["JavaScriptKit", "CHelpers"]),
     ]
 )

--- a/IntegrationTests/TestSuites/Sources/BenchmarkTests/Benchmark.swift
+++ b/IntegrationTests/TestSuites/Sources/BenchmarkTests/Benchmark.swift
@@ -8,10 +8,10 @@ class Benchmark {
     let title: String
     let runner = JSObject.global.benchmarkRunner.function!
 
-    func testSuite(_ name: String, _ body: @escaping () -> Void) {
+    func testSuite(_ name: String, _ body: @escaping (Int) -> Void) {
         let jsBody = JSClosure { arguments -> JSValue in
             let iteration = Int(arguments[0].number!)
-            for _ in 0 ..< iteration { body() }
+            body(iteration)
             return .undefined
         }
         runner("\(title)/\(name)", jsBody)

--- a/IntegrationTests/TestSuites/Sources/BenchmarkTests/main.swift
+++ b/IntegrationTests/TestSuites/Sources/BenchmarkTests/main.swift
@@ -40,6 +40,14 @@ serialization.testSuite("Swift Int to JavaScript with call") { n in
     }
 }
 
+serialization.testSuite("JavaScript Number to Swift Int") { n in
+    let object = JSObject.global
+    let key = JSString("jsNumber")
+    for _ in 0 ..< n {
+        _ = object[key].number
+    }
+}
+
 let swiftString = "Hello, world"
 serialization.testSuite("Swift String to JavaScript with assignment") { n in
     let jsString = JSValue.string(swiftString)
@@ -54,6 +62,14 @@ serialization.testSuite("Swift String to JavaScript with call") { n in
     let jsString = JSValue.string(swiftString)
     for _ in 0 ..< n {
         _ = noopFunction(jsString)
+    }
+}
+
+serialization.testSuite("JavaScript String to Swift String") { n in
+    let object = JSObject.global
+    let key = JSString("jsString")
+    for _ in 0 ..< n {
+        _ = object[key].string
     }
 }
 

--- a/IntegrationTests/TestSuites/Sources/BenchmarkTests/main.swift
+++ b/IntegrationTests/TestSuites/Sources/BenchmarkTests/main.swift
@@ -1,22 +1,59 @@
 import JavaScriptKit
+import CHelpers
 
 let serialization = Benchmark("Serialization")
 
+let noopFunction = JSObject.global.noopFunction.function!
+
+serialization.testSuite("JavaScript function call through Wasm import") { n in
+    for _ in 0 ..< n {
+        benchmark_helper_noop()
+    }
+}
+
+serialization.testSuite("JavaScript function call through Wasm import with int") { n in
+    for _ in 0 ..< n {
+        benchmark_helper_noop_with_int(42)
+    }
+}
+
+serialization.testSuite("JavaScript function call from Swift") { n in
+    for _ in 0 ..< n {
+        _ = noopFunction()
+    }
+}
+
 let swiftInt: Double = 42
-serialization.testSuite("Swift Int to JavaScript") {
+serialization.testSuite("Swift Int to JavaScript with assignment") { n in
     let jsNumber = JSValue.number(swiftInt)
     let object = JSObject.global
-    for i in 0 ..< 100 {
-        object["numberValue\(i)"] = jsNumber
+    let key = JSString("numberValue")
+    for _ in 0 ..< n {
+        object[key] = jsNumber
+    }
+}
+
+serialization.testSuite("Swift Int to JavaScript with call") { n in
+    let jsNumber = JSValue.number(swiftInt)
+    for _ in 0 ..< n {
+        _ = noopFunction(jsNumber)
     }
 }
 
 let swiftString = "Hello, world"
-serialization.testSuite("Swift String to JavaScript") {
+serialization.testSuite("Swift String to JavaScript with assignment") { n in
     let jsString = JSValue.string(swiftString)
     let object = JSObject.global
-    for i in 0 ..< 100 {
-        object["stringValue\(i)"] = jsString
+    let key = JSString("stringValue")
+    for _ in 0 ..< n {
+        object[key] = jsString
+    }
+}
+
+serialization.testSuite("Swift String to JavaScript with call") { n in
+    let jsString = JSValue.string(swiftString)
+    for _ in 0 ..< n {
+        _ = noopFunction(jsString)
     }
 }
 
@@ -25,8 +62,8 @@ let objectHeap = Benchmark("Object heap")
 let global = JSObject.global
 let Object = global.Object.function!
 global.objectHeapDummy = .object(Object.new())
-objectHeap.testSuite("Increment and decrement RC") {
-    for _ in 0 ..< 100 {
+objectHeap.testSuite("Increment and decrement RC") { n in
+    for _ in 0 ..< n {
         _ = global.objectHeapDummy
     }
 }

--- a/IntegrationTests/TestSuites/Sources/CHelpers/include/helpers.h
+++ b/IntegrationTests/TestSuites/Sources/CHelpers/include/helpers.h
@@ -3,3 +3,8 @@
 /// @param pages Number of memory pages to increase memory by.
 int growMemory(int pages);
 
+__attribute__((__import_module__("benchmark_helper"), __import_name__("noop")))
+extern void benchmark_helper_noop(void);
+
+__attribute__((__import_module__("benchmark_helper"), __import_name__("noop_with_int")))
+extern void benchmark_helper_noop_with_int(int);

--- a/IntegrationTests/bin/benchmark-tests.js
+++ b/IntegrationTests/bin/benchmark-tests.js
@@ -12,6 +12,8 @@ global.benchmarkRunner = function (name, body) {
 };
 
 global.noopFunction = function () {}
+global.jsNumber = 42
+global.jsString = "myString"
 
 class JSBenchmark {
     constructor(title) {

--- a/IntegrationTests/lib.js
+++ b/IntegrationTests/lib.js
@@ -97,6 +97,10 @@ const startWasiTask = async (wasmPath, wasiConstructor = selectWASIBackend()) =>
     let { instance } = await WebAssembly.instantiate(wasmBinary, {
         wasi_snapshot_preview1: wasi.wasiImport,
         javascript_kit: swift.importObjects(),
+        benchmark_helper: {
+            noop: () => {},
+            noop_with_int: (_) => {},
+        }
     });
 
     swift.setInstance(instance);

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,11 @@ test:
 
 .PHONY: benchmark_setup
 benchmark_setup:
-	cd IntegrationTests && make benchmark_setup
+	cd IntegrationTests && CONFIGURATION=release make benchmark_setup
 
 .PHONY: run_benchmark
 run_benchmark:
-	cd IntegrationTests && make -s run_benchmark
+	cd IntegrationTests && CONFIGURATION=release make -s run_benchmark
 
 .PHONY: perf-tester
 perf-tester:


### PR DESCRIPTION
We had been running benchmarks for a long time and they were very unstable. And also couldn't find meaningful results.

I changed to perform benchmarks with release configuration, and don't repeat noisy prelude for each benchmark.
Also added several benchmark cases to find our bridging bottlenecks (assignment, call, value conversion, ...)