### PR TITLE
Support DocC generation in Swift Package Index

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,7 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: 
+      - JavaScriptKit
+      - JavaScriptEventLoop
+      - JavaScriptBigIntSupport


### PR DESCRIPTION
This allows documentation for our package products to be generated and hosted automatically by [Swift Package Index](https://swiftpackageindex.com/swiftwasm/JavaScriptKit).

See this blog post for more details: https://blog.swiftpackageindex.com/posts/auto-generating-auto-hosting-and-auto-updating-docc-documentation