### PR TITLE
Test native builds with Xcode 14.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,8 @@ jobs:
             xcode: Xcode_13.2.1
           - os: macos-12
             xcode: Xcode_13.3
+          - os: macos-12
+            xcode: Xcode_14.0
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Xcode 14.0 beta is already available on GitHub Actions, let's try using it in our workflows.