### PR TITLE
Remove baseline tests (e.g. “Call JavaScript function directly”) from comparison

### DIFF
--- a/ci/perf-tester/src/utils.js
+++ b/ci/perf-tester/src/utils.js
@@ -168,6 +168,7 @@ exports.diffTable = (
 ) => {
     let changedRows = [];
     let unChangedRows = [];
+    let baselineRows = [];
 
     let totalTime = 0;
     let totalDelta = 0;
@@ -187,7 +188,9 @@ exports.diffTable = (
             getDeltaText(delta, difference),
             iconForDifference(difference),
         ];
-        if (isUnchanged && collapseUnchanged) {
+        if (name.includes('directly')) {
+            baselineRows.push(columns);
+        } else if (isUnchanged && collapseUnchanged) {
             unChangedRows.push(columns);
         } else {
             changedRows.push(columns);
@@ -199,6 +202,11 @@ exports.diffTable = (
     if (unChangedRows.length !== 0) {
         const outUnchanged = markdownTable(unChangedRows);
         out += `\n\n<details><summary><strong>View Unchanged</strong></summary>\n\n${outUnchanged}\n\n</details>\n\n`;
+    }
+    
+    if (baselineRows.length !== 0) {
+        const outBaseline = markdownTable(baselineRows.map(line => line.slice(0, 2));
+        out += `\n\n<details><summary><strong>View Baselines</strong></summary>\n\n${outBaseline}\n\n</details>\n\n`;
     }
 
     if (showTotal) {

--- a/ci/perf-tester/src/utils.js
+++ b/ci/perf-tester/src/utils.js
@@ -205,7 +205,7 @@ exports.diffTable = (
     }
     
     if (baselineRows.length !== 0) {
-        const outBaseline = markdownTable(baselineRows.map(line => line.slice(0, 2));
+        const outBaseline = markdownTable(baselineRows.map(line => line.slice(0, 2)));
         out += `\n\n<details><summary><strong>View Baselines</strong></summary>\n\n${outBaseline}\n\n</details>\n\n`;
     }
 


### PR DESCRIPTION
See below comment for an example. Changes to speed in these tests is not at all useful for us to track since they’re directly related to the speed of the JS engine, and are just a target for us to one day match.