### PR TITLE
Support Clock-based sleep APIs

### DIFF
--- a/Sources/JavaScriptEventLoop/JavaScriptEventLoop.swift
+++ b/Sources/JavaScriptEventLoop/JavaScriptEventLoop.swift
@@ -143,6 +143,7 @@ internal func swift_get_time(
   _ nanoseconds: UnsafeMutablePointer<Int64>,
   _ clock: CInt)
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension JavaScriptEventLoop {
     fileprivate func enqueue(
         _ job: UnownedJob, withDelay seconds: Int64, _ nanoseconds: Int64,

--- a/Sources/JavaScriptEventLoop/JavaScriptEventLoop.swift
+++ b/Sources/JavaScriptEventLoop/JavaScriptEventLoop.swift
@@ -102,6 +102,14 @@ public final class JavaScriptEventLoop: SerialExecutor, @unchecked Sendable {
         }
         swift_task_enqueueGlobalWithDelay_hook = unsafeBitCast(swift_task_enqueueGlobalWithDelay_hook_impl, to: UnsafeMutableRawPointer?.self)
 
+        #if compiler(>=5.7)
+        typealias swift_task_enqueueGlobalWithDeadline_hook_Fn = @convention(thin) (Int64, Int64, Int64, Int64, Int32, UnownedJob, swift_task_enqueueGlobalWithDelay_original) -> Void
+        let swift_task_enqueueGlobalWithDeadline_hook_impl: swift_task_enqueueGlobalWithDeadline_hook_Fn = { sec, nsec, tsec, tnsec, clock, job, original in
+            JavaScriptEventLoop.shared.enqueue(job, withDelay: sec, nsec, tsec, tnsec, clock)
+        }
+        swift_task_enqueueGlobalWithDeadline_hook = unsafeBitCast(swift_task_enqueueGlobalWithDeadline_hook_impl, to: UnsafeMutableRawPointer?.self)
+        #endif
+
         typealias swift_task_enqueueMainExecutor_hook_Fn = @convention(thin) (UnownedJob, swift_task_enqueueMainExecutor_original) -> Void
         let swift_task_enqueueMainExecutor_hook_impl: swift_task_enqueueMainExecutor_hook_Fn = { job, original in
             JavaScriptEventLoop.shared.enqueue(job)
@@ -126,6 +134,29 @@ public final class JavaScriptEventLoop: SerialExecutor, @unchecked Sendable {
         return UnownedSerialExecutor(ordinary: self)
     }
 }
+
+#if compiler(>=5.7)
+/// Taken from https://github.com/apple/swift/blob/d375c972f12128ec6055ed5f5337bfcae3ec67d8/stdlib/public/Concurrency/Clock.swift#L84-L88
+@_silgen_name("swift_get_time")
+internal func swift_get_time(
+  _ seconds: UnsafeMutablePointer<Int64>,
+  _ nanoseconds: UnsafeMutablePointer<Int64>,
+  _ clock: CInt)
+
+extension JavaScriptEventLoop {
+    fileprivate func enqueue(
+        _ job: UnownedJob, withDelay seconds: Int64, _ nanoseconds: Int64,
+        _ toleranceSec: Int64, _ toleranceNSec: Int64,
+        _ clock: Int32
+    ) {
+        var nowSec: Int64 = 0
+        var nowNSec: Int64 = 0
+        swift_get_time(&nowSec, &nowNSec, clock)
+        let delayNanosec = (seconds - nowSec) * 1_000_000_000 + (nanoseconds - nowNSec)
+        enqueue(job, withDelay: delayNanosec <= 0 ? 0 : UInt64(delayNanosec))
+    }
+}
+#endif
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public extension JSPromise {

--- a/Sources/_CJavaScriptEventLoop/include/_CJavaScriptEventLoop.h
+++ b/Sources/_CJavaScriptEventLoop/include/_CJavaScriptEventLoop.h
@@ -35,7 +35,14 @@ typedef SWIFT_CC(swift) void (*swift_task_enqueueGlobalWithDelay_original)(
 SWIFT_EXPORT_FROM(swift_Concurrency)
 void *_Nullable swift_task_enqueueGlobalWithDelay_hook;
 
-unsigned long long foo;
+typedef SWIFT_CC(swift) void (*swift_task_enqueueGlobalWithDeadline_original)(
+    long long sec,
+    long long nsec,
+    long long tsec,
+    long long tnsec,
+    int clock, Job *_Nonnull job);
+SWIFT_EXPORT_FROM(swift_Concurrency)
+void *_Nullable swift_task_enqueueGlobalWithDeadline_hook;
 
 /// A hook to take over main executor enqueueing.
 typedef SWIFT_CC(swift) void (*swift_task_enqueueMainExecutor_original)(


### PR DESCRIPTION
This PR adds support for `Task.sleep(until:clock:)` and other Clock sleep API family.