### PR TITLE
Add `withUnsafeBytesAsync` function to `JSTypedArray`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
       matrix:
         entry:
           # Ensure that all host can install toolchain, build project, and run tests
-          - { os: macos-10.15,  toolchain: wasm-5.6.0-RELEASE, wasi-backend: Node }
-          - { os: macos-11,     toolchain: wasm-5.6.0-RELEASE, wasi-backend: Node }
-          - { os: macos-12,     toolchain: wasm-5.6.0-RELEASE, wasi-backend: Node }
+          - { os: macos-10.15,  toolchain: wasm-5.6.0-RELEASE, wasi-backend: Node, xcode: Xcode_12.4.app }
+          - { os: macos-11,     toolchain: wasm-5.6.0-RELEASE, wasi-backend: Node, xcode: Xcode_13.2.1.app }
+          - { os: macos-12,     toolchain: wasm-5.6.0-RELEASE, wasi-backend: Node, xcode: Xcode_13.4.1.app }
           - { os: ubuntu-18.04, toolchain: wasm-5.6.0-RELEASE, wasi-backend: Node }
 
           # Ensure that test succeeds with all toolchains and wasi backend combinations
@@ -33,6 +33,9 @@ jobs:
         uses: actions/checkout@master
         with:
           fetch-depth: 1
+      - name: Select SDKROOT
+        if: ${{ matrix.entry.xcode }}
+        run: sudo xcode-select -s /Applications/${{ matrix.entry.xcode }}
       - uses: swiftwasm/setup-swiftwasm@v1
         with:
           swift-version: ${{ matrix.entry.toolchain }}

--- a/Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift
@@ -88,31 +88,34 @@ public class JSTypedArray<Element>: JSBridgedClass, ExpressibleByArrayLiteral wh
         let result = try body(bufferPtr)
         return result
     }
-    
-    /// Calls the given async closure with a pointer to a copy of the underlying bytes of the
-    /// array's storage.
-    ///
-    /// - Note: The pointer passed as an argument to `body` is valid only for the
-    /// lifetime of the closure. Do not escape it from the async closure for later
-    /// use.
-    ///
-    /// - Parameter body: A closure with an `UnsafeBufferPointer` parameter
-    ///   that points to the contiguous storage for the array.
-    ///    If `body` has a return value, that value is also
-    ///   used as the return value for the `withUnsafeBytes(_:)` method. The
-    ///   argument is valid only for the duration of the closure's execution.
-    /// - Returns: The return value, if any, of the `body`async closure parameter.
-    public func withUnsafeBytesAsync<R>(_ body: (UnsafeBufferPointer<Element>) async throws -> R) async rethrows -> R {
-        let bytesLength = lengthInBytes
-        let rawBuffer = malloc(bytesLength)!
-        defer { free(rawBuffer) }
-        _load_typed_array(jsObject.id, rawBuffer.assumingMemoryBound(to: UInt8.self))
-        let length = lengthInBytes / MemoryLayout<Element>.size
-        let boundPtr = rawBuffer.bindMemory(to: Element.self, capacity: length)
-        let bufferPtr = UnsafeBufferPointer<Element>(start: boundPtr, count: length)
-        let result = try await body(bufferPtr)
-        return result
-    }
+
+    #if compiler(>=5.5)
+        /// Calls the given async closure with a pointer to a copy of the underlying bytes of the
+        /// array's storage.
+        ///
+        /// - Note: The pointer passed as an argument to `body` is valid only for the
+        /// lifetime of the closure. Do not escape it from the async closure for later
+        /// use.
+        ///
+        /// - Parameter body: A closure with an `UnsafeBufferPointer` parameter
+        ///   that points to the contiguous storage for the array.
+        ///    If `body` has a return value, that value is also
+        ///   used as the return value for the `withUnsafeBytes(_:)` method. The
+        ///   argument is valid only for the duration of the closure's execution.
+        /// - Returns: The return value, if any, of the `body`async closure parameter.
+        @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+        public func withUnsafeBytesAsync<R>(_ body: (UnsafeBufferPointer<Element>) async throws -> R) async rethrows -> R {
+            let bytesLength = lengthInBytes
+            let rawBuffer = malloc(bytesLength)!
+            defer { free(rawBuffer) }
+            _load_typed_array(jsObject.id, rawBuffer.assumingMemoryBound(to: UInt8.self))
+            let length = lengthInBytes / MemoryLayout<Element>.size
+            let boundPtr = rawBuffer.bindMemory(to: Element.self, capacity: length)
+            let bufferPtr = UnsafeBufferPointer<Element>(start: boundPtr, count: length)
+            let result = try await body(bufferPtr)
+            return result
+        }
+    #endif
 }
 
 // MARK: - Int and UInt support

--- a/Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift
@@ -88,6 +88,31 @@ public class JSTypedArray<Element>: JSBridgedClass, ExpressibleByArrayLiteral wh
         let result = try body(bufferPtr)
         return result
     }
+    
+    /// Calls the given async closure with a pointer to a copy of the underlying bytes of the
+    /// array's storage.
+    ///
+    /// - Note: The pointer passed as an argument to `body` is valid only for the
+    /// lifetime of the closure. Do not escape it from the async closure for later
+    /// use.
+    ///
+    /// - Parameter body: A closure with an `UnsafeBufferPointer` parameter
+    ///   that points to the contiguous storage for the array.
+    ///    If `body` has a return value, that value is also
+    ///   used as the return value for the `withUnsafeBytes(_:)` method. The
+    ///   argument is valid only for the duration of the closure's execution.
+    /// - Returns: The return value, if any, of the `body`async closure parameter.
+    public func withUnsafeBytesAsync<R>(_ body: (UnsafeBufferPointer<Element>) async throws -> R) async rethrows -> R {
+        let bytesLength = lengthInBytes
+        let rawBuffer = malloc(bytesLength)!
+        defer { free(rawBuffer) }
+        _load_typed_array(jsObject.id, rawBuffer.assumingMemoryBound(to: UInt8.self))
+        let length = lengthInBytes / MemoryLayout<Element>.size
+        let boundPtr = rawBuffer.bindMemory(to: Element.self, capacity: length)
+        let bufferPtr = UnsafeBufferPointer<Element>(start: boundPtr, count: length)
+        let result = try await body(bufferPtr)
+        return result
+    }
 }
 
 // MARK: - Int and UInt support


### PR DESCRIPTION
## Description

We could face some scenarios when the piece of code used inside of the `withUnsafeBytes` block could be `async code`, so this is why I have created this new function `withUnsafeBytesAsync` for such scenarios.

Cheers.