### PR TITLE
Fix warnings Aug 5, 2023

### DIFF
--- a/Sources/JavaScriptKit/ConvertibleToJSValue.swift
+++ b/Sources/JavaScriptKit/ConvertibleToJSValue.swift
@@ -256,7 +256,7 @@ extension Array where Element == ConvertibleToJSValue {
         // fast path for empty array
         guard self.count != 0 else { return body([]) }
 
-        func _withRawJSValues<T>(
+        func _withRawJSValues(
             _ values: [ConvertibleToJSValue], _ index: Int,
             _ results: inout [RawJSValue], _ body: ([RawJSValue]) -> T
         ) -> T {

--- a/Sources/_CJavaScriptBigIntSupport/include/_CJavaScriptKit+I64.h
+++ b/Sources/_CJavaScriptBigIntSupport/include/_CJavaScriptKit+I64.h
@@ -8,16 +8,20 @@
 ///
 /// @param value The value to convert.
 /// @param is_signed Whether to treat the value as a signed integer or not.
+#if __wasi__
 __attribute__((__import_module__("javascript_kit"),
                __import_name__("swjs_i64_to_bigint")))
+#endif
 extern JavaScriptObjectRef _i64_to_bigint(const long long value, bool is_signed);
 
 /// Converts the provided BigInt to an Int64 or UInt64.
 ///
 /// @param ref The target JavaScript object.
 /// @param is_signed Whether to treat the return value as a signed integer or not.
+#if __wasi__
 __attribute__((__import_module__("javascript_kit"),
                __import_name__("swjs_bigint_to_i64")))
+#endif
 extern long long _bigint_to_i64(const JavaScriptObjectRef ref, bool is_signed);
 
 #endif /* _CJavaScriptBigIntSupport_h */


### PR DESCRIPTION
- Preemptively fixes a Swift 6 colliding generics definitions error
- Fixes a minor issue with Xcode IDE support where some warnings were shown to users
  - These warnings can seem intimidating or even be frustrating for users who prefer to fix all warnings