### PR TITLE
Fix availability marker for Swift 5.9 compiler targeting host machine

### DIFF
--- a/Sources/JavaScriptEventLoop/JobQueue.swift
+++ b/Sources/JavaScriptEventLoop/JobQueue.swift
@@ -12,7 +12,7 @@ struct QueueState: Sendable {
     fileprivate var isSpinning: Bool = false
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 extension JavaScriptEventLoop {
 
     func insertJobQueue(job newJob: UnownedJob) {

--- a/Sources/JavaScriptEventLoopTestSupport/JavaScriptEventLoopTestSupport.swift
+++ b/Sources/JavaScriptEventLoopTestSupport/JavaScriptEventLoopTestSupport.swift
@@ -22,7 +22,7 @@ import JavaScriptEventLoop
 
 #if compiler(>=5.5)
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 @_cdecl("swift_javascriptkit_activate_js_executor_impl")
 func swift_javascriptkit_activate_js_executor_impl() {
     JavaScriptEventLoop.installGlobalExecutor()


### PR DESCRIPTION
When building JavaScriptKit with Xcode, targeting host machine, the `func enqueue(_: ExecutorJob)` must be guarded by `@available` attribute explicitly. And due to the 5.9 compiler issue, it emit some migration warnings too consevatively. This commit suppress the warning by updating minimum available OS versions. Those versions should not be a problem when building for Wasm.