### PR TITLE
Update swift-tools-version to reflect the supported Swift versions

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -13,6 +13,8 @@ jobs:
         with:
           fetch-depth: 1
       - uses: swiftwasm/setup-swiftwasm@v1
+        with:
+          swift-version: wasm-5.9.1-RELEASE
       - name: Run Test
         run: |
           set -eux

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -11,6 +11,8 @@ jobs:
         with:
           fetch-depth: 1
       - uses: swiftwasm/setup-swiftwasm@v1
+        with:
+          swift-version: wasm-5.9.1-RELEASE
       - name: Run Benchmark
         run: |
           make bootstrap

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,8 +58,6 @@ jobs:
       matrix:
         include:
           - os: macos-12
-            xcode: Xcode_13.3
-          - os: macos-12
             xcode: Xcode_14.0
           - os: macos-13
             xcode: Xcode_14.3

--- a/Example/JavaScriptKitExample/Package.swift
+++ b/Example/JavaScriptKitExample/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.7
 
 import PackageDescription
 

--- a/IntegrationTests/TestSuites/Package.swift
+++ b/IntegrationTests/TestSuites/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.7
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.7
 
 import PackageDescription
 


### PR DESCRIPTION
Swift 5.5 and 5.6 supports are dropped in #229 / https://github.com/swiftwasm/JavaScriptKit/pull/229/commits/a70c1e5dc4d931e97e66a98e74712ec29326efcb ([0.19.0](https://github.com/swiftwasm/JavaScriptKit/releases/tag/0.19.0)).