### PR TITLE
Fix Optional implementation for ConstructibleFromJSValue

### DIFF
--- a/Sources/JavaScriptKit/ConvertibleToJSValue.swift
+++ b/Sources/JavaScriptKit/ConvertibleToJSValue.swift
@@ -131,9 +131,10 @@ extension Optional: ConstructibleFromJSValue where Wrapped: ConstructibleFromJSV
     public static func construct(from value: JSValue) -> Self? {
         switch value {
         case .null, .undefined:
-            return nil
+            return .some(nil)
         default:
-            return Wrapped.construct(from: value)
+            guard let wrapped = Wrapped.construct(from: value) else { return nil }
+            return .some(wrapped)
         }
     }
 }


### PR DESCRIPTION
現在の実装ではJSの値として `null`, `undefined` の場合に、
`Optional.construct` が `nil` を返していますが、
これはデコードの失敗を意味するため間違っています。

適切に `Optional.none` がデコードできた状況なので、 `.some(nil)` を返す必要があります。

また、 `Wrapped.construct` が `nil` を返した場合は、
デコード失敗なので `nil` を返すべきですが、
ここで暗黙のキャストによって `.some(nil)` が返ってしまうかどうか分かりづらいと思ったので、
明示的に guard 文で分岐するように書き換えてみました。