### PR TITLE
Fix `JSClosure` leak

### DIFF
--- a/IntegrationTests/TestSuites/Sources/ConcurrencyTests/main.swift
+++ b/IntegrationTests/TestSuites/Sources/ConcurrencyTests/main.swift
@@ -123,12 +123,16 @@ func entrypoint() async throws {
             try expectEqual(result, .number(3))
         }
         try expectGTE(diff, 200)
+#if JAVASCRIPTKIT_WITHOUT_WEAKREFS
+        delayObject.closure = nil
+        delayClosure.release()
+#endif
     }
 
     try await asyncTest("Async JSPromise: then") {
         let promise = JSPromise { resolve in
             _ = JSObject.global.setTimeout!(
-                JSClosure { _  in
+                JSOneshotClosure { _  in
                     resolve(.success(JSValue.number(3)))
                     return .undefined
                 }.jsValue,
@@ -149,7 +153,7 @@ func entrypoint() async throws {
     try await asyncTest("Async JSPromise: then(success:failure:)") {
         let promise = JSPromise { resolve in
             _ = JSObject.global.setTimeout!(
-                JSClosure { _ in
+                JSOneshotClosure { _ in
                     resolve(.failure(JSError(message: "test").jsValue))
                     return .undefined
                 }.jsValue,
@@ -168,7 +172,7 @@ func entrypoint() async throws {
     try await asyncTest("Async JSPromise: catch") {
         let promise = JSPromise { resolve in
             _ = JSObject.global.setTimeout!(
-                JSClosure { _ in
+                JSOneshotClosure { _ in
                     resolve(.failure(JSError(message: "test").jsValue))
                     return .undefined
                 }.jsValue,

--- a/IntegrationTests/TestSuites/Sources/PrimaryTests/UnitTestUtils.swift
+++ b/IntegrationTests/TestSuites/Sources/PrimaryTests/UnitTestUtils.swift
@@ -111,7 +111,7 @@ func expectThrow<T>(_ body: @autoclosure () throws -> T, file: StaticString = #f
 }
 
 func wrapUnsafeThrowableFunction(_ body: @escaping () -> Void, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws -> Error {
-    JSObject.global.callThrowingClosure.function!(JSClosure { _ in 
+    JSObject.global.callThrowingClosure.function!(JSOneshotClosure { _ in
             body() 
             return .undefined
     })

--- a/Sources/JavaScriptKit/FundamentalObjects/JSClosure.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSClosure.swift
@@ -64,6 +64,8 @@ public class JSClosure: JSFunction, JSClosureProtocol {
     private var hostFuncRef: JavaScriptHostFuncRef = 0
 
     #if JAVASCRIPTKIT_WITHOUT_WEAKREFS
+    private let file: String
+    private let line: UInt32
     private var isReleased: Bool = false
     #endif
 
@@ -77,6 +79,10 @@ public class JSClosure: JSFunction, JSClosureProtocol {
     }
 
     public init(_ body: @escaping ([JSValue]) -> JSValue, file: String = #fileID, line: UInt32 = #line) {
+        #if JAVASCRIPTKIT_WITHOUT_WEAKREFS
+        self.file = file
+        self.line = line
+        #endif
         // 1. Fill `id` as zero at first to access `self` to get `ObjectIdentifier`.
         super.init(id: 0)
 
@@ -94,15 +100,15 @@ public class JSClosure: JSFunction, JSClosureProtocol {
 
     #if compiler(>=5.5)
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-    public static func async(_ body: @escaping ([JSValue]) async throws -> JSValue) -> JSClosure {
-        JSClosure(makeAsyncClosure(body))
+    public static func async(_ body: @escaping ([JSValue]) async throws -> JSValue, file: String = #fileID, line: UInt32 = #line) -> JSClosure {
+        JSClosure(makeAsyncClosure(body), file: file, line: line)
     }
     #endif
 
     #if JAVASCRIPTKIT_WITHOUT_WEAKREFS
     deinit {
         guard isReleased else {
-            fatalError("release() must be called on JSClosure objects manually before they are deallocated")
+            fatalError("release() must be called on JSClosure object (\(file):\(line)) manually before they are deallocated")
         }
     }
     #endif


### PR DESCRIPTION
```swift
let c1 = JSClosure { _ in .undefined }
consume c1
```

did not release the `JSClosure` itself and it leaked the underlying
JavaScript closure too because `JSClosure` -> JS closure thunk ->
Closure registry entry -> `JSClosure` reference cycle was not broken
when using FinalizationRegistry. (Without FR, it was broken by manual
`release` call.)

Note that weakening the reference does not violates the contract that
function reference should be unique because holding a weak reference does
deinit but not deallocate the object, so ObjectIdentifier is not reused
until the weak reference in the registry is removed.