### PR TITLE
Fix object decode

### DIFF
--- a/IntegrationTests/TestSuites/Sources/PrimaryTests/UnitTestUtils.swift
+++ b/IntegrationTests/TestSuites/Sources/PrimaryTests/UnitTestUtils.swift
@@ -123,6 +123,13 @@ func expectNotNil<T>(_ value: T?, file: StaticString = #file, line: UInt = #line
         throw MessageError("Expect a non-nil value", file: file, line: line, column: column)
     }
 }
+func expectNil<T>(_ value: T?, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
+    switch value {
+    case .some:
+        throw MessageError("Expect an nil", file: file, line: line, column: column)
+    case .none: return
+    }
+}
 
 class Expectation {
     private(set) var isFulfilled: Bool = false

--- a/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
+++ b/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
@@ -337,6 +337,48 @@ try test("New Object Construction") {
     try expectEqual(dog1Bark(), .string("wan"))
 }
 
+try test("Object Decoding") {
+    /* 
+     ```js
+     global.objectDecodingTest = {
+         obj: {},
+         fn: () => {},
+         sym: Symbol("s"),
+         bi: BigInt(3)
+     };
+     ```
+     */
+    let js: JSValue = JSObject.global.objectDecodingTest
+
+    // I can't use regular name like `js.object` here
+    // cz its conflicting with case name and DML.
+    // so I use abbreviated names
+    let object: JSValue = js.obj
+    let function: JSValue = js.fn
+    let symbol: JSValue = js.sym
+    let bigInt: JSValue = js.bi
+
+    try expectNotNil(JSObject.construct(from: object))
+    try expectNotNil(JSObject.construct(from: function))
+    try expectNotNil(JSObject.construct(from: symbol))
+    try expectNotNil(JSObject.construct(from: bigInt))
+
+    try expectNil(JSFunction.construct(from: object))
+    try expectNotNil(JSFunction.construct(from: function))
+    try expectNil(JSFunction.construct(from: symbol))
+    try expectNil(JSFunction.construct(from: bigInt))
+
+    try expectNil(JSSymbol.construct(from: object))
+    try expectNil(JSSymbol.construct(from: function))
+    try expectNotNil(JSSymbol.construct(from: symbol))
+    try expectNil(JSSymbol.construct(from: bigInt))
+
+    try expectNil(JSBigInt.construct(from: object))
+    try expectNil(JSBigInt.construct(from: function))
+    try expectNil(JSBigInt.construct(from: symbol))
+    try expectNotNil(JSBigInt.construct(from: bigInt))
+}
+
 try test("Call Function With This") {
     // ```js
     // global.Animal = function(name, age, isCat) {

--- a/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
+++ b/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
@@ -359,9 +359,9 @@ try test("Object Decoding") {
     let bigInt: JSValue = js.bi
 
     try expectNotNil(JSObject.construct(from: object))
-    try expectNotNil(JSObject.construct(from: function))
-    try expectNotNil(JSObject.construct(from: symbol))
-    try expectNotNil(JSObject.construct(from: bigInt))
+    try expectEqual(JSObject.construct(from: function).map { $0 is JSFunction }, .some(true))
+    try expectEqual(JSObject.construct(from: symbol).map { $0 is JSSymbol }, .some(true))
+    try expectEqual(JSObject.construct(from: bigInt).map { $0 is JSBigInt }, .some(true))
 
     try expectNil(JSFunction.construct(from: object))
     try expectNotNil(JSFunction.construct(from: function))

--- a/IntegrationTests/bin/primary-tests.js
+++ b/IntegrationTests/bin/primary-tests.js
@@ -95,6 +95,13 @@ global.callThrowingClosure = (c) => {
     }
 };
 
+global.objectDecodingTest = {
+    obj: {},
+    fn: () => {},
+    sym: Symbol("s"),
+    bi: BigInt(3)
+};
+
 const { startWasiTask, WASI } = require("../lib");
 
 startWasiTask("./dist/PrimaryTests.wasm").catch((err) => {

--- a/IntegrationTests/package-lock.json
+++ b/IntegrationTests/package-lock.json
@@ -13,7 +13,7 @@
     },
     "..": {
       "name": "javascript-kit-swift",
-      "version": "0.18.0",
+      "version": "0.19.1",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^8.3.1",

--- a/Sources/JavaScriptKit/FundamentalObjects/JSBigInt.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSBigInt.swift
@@ -24,10 +24,6 @@ public final class JSBigInt: JSObject {
         super.init(id: _i64_to_bigint_slow(UInt32(value & 0xffffffff), UInt32(value >> 32), false))
     }
 
-    override public class func construct(from value: JSValue) -> Self? {
-        value.bigInt as? Self
-    }
-
     override public var jsValue: JSValue {
         .bigInt(self)
     }

--- a/Sources/JavaScriptKit/FundamentalObjects/JSFunction.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSFunction.swift
@@ -89,10 +89,6 @@ public class JSFunction: JSObject {
         fatalError("unavailable")
     }
 
-    override public class func construct(from value: JSValue) -> Self? {
-        return value.function as? Self
-    }
-
     override public var jsValue: JSValue {
         .function(self)
     }

--- a/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
@@ -150,8 +150,22 @@ public class JSObject: Equatable {
         return lhs.id == rhs.id
     }
 
-    public class func construct(from value: JSValue) -> Self? {
-        return value.object as? Self
+    public static func construct(from value: JSValue) -> Self? {
+        switch value {
+        case .boolean,
+                .string,
+                .number,
+                .null,
+                .undefined: return nil
+        case .object(let object):
+            return object as? Self
+        case .function(let function):
+            return function as? Self
+        case .symbol(let symbol):
+            return symbol as? Self
+        case .bigInt(let bigInt):
+            return bigInt as? Self
+        }
     }
 
     public var jsValue: JSValue {

--- a/Sources/JavaScriptKit/FundamentalObjects/JSSymbol.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSSymbol.swift
@@ -41,10 +41,6 @@ public class JSSymbol: JSObject {
         Symbol.keyFor!(symbol).string
     }
 
-    override public class func construct(from value: JSValue) -> Self? {
-        return value.symbol as? Self
-    }
-
     override public var jsValue: JSValue {
         .symbol(self)
     }


### PR DESCRIPTION
The current `JSObject.construct(from:)` failed with `JSValue`s where its case is function, symbol, or bigInt. 

For example, `JSFunction.construct` succeeds with `case function` and `JSObject.construct` doesn't, but it should succeed because `JSFunction` is a `JSObject`.

symbol and bigint are primitive values in JavaScript side, and because of:

```js
Symbol("s") instanceof Object // false
```

It's unclear if `JSObject.construct(symbol)` should succeed or nor, but I think it should because `JSSymbol` is a `JSObject`.

Note for `function` case:

```js
(() => {}) instanceof Object // true
```

---

従来の実装では、`JSValue` の case が function, symbol, bigInt であるような JSValue を、
`JSObject.construct(from:)` に渡した場合にデコードに失敗していました。

例えば `JSFunction.construct` に case function を渡す場合は成功しますが、
値がfunction であるとわからない状況においても、
`JSFunction` is `JSObject` である以上、 `JSObject` としてのデコードが成功する必要があります。

symbol と bigInt については JavaScript側においてはプリミティブであり、

```js
Symbol("s") instanceof Object // false
```

なので、 `JSObject` としてデコードできるのが正しいのかよくわからないですが、
少なくとも `JSSymbol` is `JSObject` となっている以上は、
そうなるべきだと思います。

ちなみに function については

```js
(() => {}) instanceof Object // true
```

です。