### PR TITLE
Update README file to include new carton 1.0 implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,20 @@ Not all of these versions are tested on regular basis though, compatibility repo
 ## Usage in a browser application
 
 The easiest way to get started with JavaScriptKit in your browser app is with [the `carton`
-bundler](https://carton.dev).
+bundler](https://carton.dev). Add carton to your swift package dependencies:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/swiftwasm/carton", from: "1.0.0"),
+],
+```
+
+> [!WARNING]
+> - If you already use `carton` before 0.x.x versions via Homebrew, you can remove it with `brew uninstall carton` and install the new version as a SwiftPM dependency.
+> - Also please remove the old `.build` directory before using the new `carton`
+
+## Legacy Installation
+
 
 As a part of these steps
 you'll install `carton` via [Homebrew](https://brew.sh/) on macOS (you can also use the

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ a few additional steps though (you can skip these steps if your app depends on
     name: "JavaScriptKitExample",
     dependencies: [
         "JavaScriptKit",
-        .package(url: "https://github.com/swiftwasm/carton", from: "1.0.0"),
         .product(name: "JavaScriptEventLoop", package: "JavaScriptKit"),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ a few additional steps though (you can skip these steps if your app depends on
     name: "JavaScriptKitExample",
     dependencies: [
         "JavaScriptKit",
-        .product(name: "JavaScriptEventLoop", package: "JavaScriptKit")
+        .package(url: "https://github.com/swiftwasm/carton", from: "1.0.0"),
+        .product(name: "JavaScriptEventLoop", package: "JavaScriptKit"),
     ]
 )
 ```

--- a/README.md
+++ b/README.md
@@ -181,10 +181,22 @@ Not all of these versions are tested on regular basis though, compatibility repo
 The easiest way to get started with JavaScriptKit in your browser app is with [the `carton`
 bundler](https://carton.dev). Add carton to your swift package dependencies:
 
-```swift
+```diff
 dependencies: [
-    .package(url: "https://github.com/swiftwasm/carton", from: "1.0.0"),
++    .package(url: "https://github.com/swiftwasm/carton", from: "1.0.0"),
 ],
+```
+
+Now you can activate the package dependency through swift:
+
+```
+swift run carton dev
+```
+
+If you have multiple products in your package, you can also used the product flag:
+
+```
+swift run carton dev --product MyApp
 ```
 
 > [!WARNING]

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ dependencies: [
 
 <details><summary>Legacy Installation</summary>
 
+---
 
 As a part of these steps
 you'll install `carton` via [Homebrew](https://brew.sh/) on macOS (you can also use the
@@ -230,6 +231,8 @@ carton init --template basic
 ```
 carton dev
 ```
+
+---
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ dependencies: [
 > - If you already use `carton` before 0.x.x versions via Homebrew, you can remove it with `brew uninstall carton` and install the new version as a SwiftPM dependency.
 > - Also please remove the old `.build` directory before using the new `carton`
 
-## Legacy Installation
+<details><summary>Legacy Installation</summary>
 
 
 As a part of these steps
@@ -231,6 +231,8 @@ carton init --template basic
 ```
 carton dev
 ```
+
+</details>
 
 5. Open [http://127.0.0.1:8080/](http://127.0.0.1:8080/) in your browser and a developer console
    within it. You'll see `Hello, world!` output in the console. You can edit the app source code in


### PR DESCRIPTION
Update the README and left the legacy implementation in there just in case someone comes across some old examples.