### PR TITLE
Use Swift SDK for development snapshot testing in CI

### DIFF
--- a/.github/actions/install-swift/action.yml
+++ b/.github/actions/install-swift/action.yml
@@ -1,0 +1,44 @@
+inputs:
+  swift-dir:
+    description: The directory name part of the distribution URL
+    required: true
+  swift-version:
+    description: Git tag indicating the Swift version
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # https://www.swift.org/install/linux/#installation-via-tarball
+    - name: Install dependent packages for Swift
+      shell: bash
+      run: >
+        sudo apt-get -q update &&
+        sudo apt-get install -y
+        binutils
+        git
+        gnupg2
+        libc6-dev
+        libcurl4-openssl-dev
+        libedit2
+        libgcc-9-dev
+        libpython3.8
+        libsqlite3-0
+        libstdc++-9-dev
+        libxml2-dev
+        libz3-dev
+        pkg-config
+        tzdata
+        unzip
+        zlib1g-dev
+        curl
+
+    - name: Download Swift
+      shell: bash
+      run: curl -fLO https://download.swift.org/${{ inputs.swift-dir }}/${{ inputs.swift-version }}/${{ inputs.swift-version }}-ubuntu22.04.tar.gz
+      working-directory: ${{ env.RUNNER_TEMP }}
+
+    - name: Unarchive and Install Swift
+      shell: bash
+      run: sudo tar -xf ${{ inputs.swift-version }}-ubuntu22.04.tar.gz --strip-components=2 -C /usr/local
+      working-directory: ${{ env.RUNNER_TEMP }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,19 @@ jobs:
           - { os: ubuntu-20.04, toolchain: wasm-5.7.3-RELEASE, wasi-backend: MicroWASI }
           - { os: ubuntu-20.04, toolchain: wasm-5.8.0-RELEASE, wasi-backend: MicroWASI }
           - { os: ubuntu-20.04, toolchain: wasm-5.9.1-RELEASE, wasi-backend: MicroWASI }
-          - { os: ubuntu-22.04, toolchain: wasm-DEVELOPMENT-SNAPSHOT-2024-05-02-a, wasi-backend: Node }
+          - os: ubuntu-22.04
+            toolchain: DEVELOPMENT-SNAPSHOT-2024-05-01-a
+            swift-sdk:
+              id: DEVELOPMENT-SNAPSHOT-2024-05-25-a-wasm32-unknown-wasi
+              download-url: "https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-05-25-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-05-25-a-wasm32-unknown-wasi.artifactbundle.zip"
+            wasi-backend: Node
+          # TODO: Enable this once we support threads in JavaScriptKit
+          # - os: ubuntu-22.04
+          #   toolchain: DEVELOPMENT-SNAPSHOT-2024-05-01-a
+          #   swift-sdk:
+          #     id: DEVELOPMENT-SNAPSHOT-2024-05-25-a-wasm32-unknown-wasip1-threads
+          #     download-url: "https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-05-25-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-05-25-a-wasm32-unknown-wasip1-threads.artifactbundle.zip"
+          #   wasi-backend: Node
 
     runs-on: ${{ matrix.entry.os }}
     env:
@@ -34,8 +46,19 @@ jobs:
         if: ${{ matrix.entry.xcode }}
         run: sudo xcode-select -s /Applications/${{ matrix.entry.xcode }}
       - uses: swiftwasm/setup-swiftwasm@v1
+        if: ${{ matrix.entry.swift-sdk == null }}
         with:
           swift-version: ${{ matrix.entry.toolchain }}
+      - uses: ./.github/actions/install-swift
+        if: ${{ matrix.entry.swift-sdk }}
+        with:
+          swift-dir: development/ubuntu2204
+          swift-version: swift-${{ matrix.entry.toolchain }}
+      - name: Install Swift SDK
+        if: ${{ matrix.entry.swift-sdk }}
+        run: |
+          swift sdk install "${{ matrix.entry.swift-sdk.download-url }}"
+          echo "SWIFT_SDK_ID=${{ matrix.entry.swift-sdk.id }}" >> $GITHUB_ENV
       - run: make bootstrap
       - run: make test
       - run: make unittest

--- a/IntegrationTests/Makefile
+++ b/IntegrationTests/Makefile
@@ -8,7 +8,6 @@ FORCE:
 TestSuites/.build/$(CONFIGURATION)/%.wasm: FORCE
 	swift build --package-path TestSuites \
 	            --product $(basename $(notdir $@)) \
-	            --triple wasm32-unknown-wasi \
 	            --configuration $(CONFIGURATION) \
 	            -Xswiftc -Xclang-linker -Xswiftc -mexec-model=reactor \
 	            -Xlinker --export-if-defined=main -Xlinker --export-if-defined=__main_argc_argv \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 MAKEFILE_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
+ifeq ($(SWIFT_SDK_ID),)
+SWIFT_BUILD_FLAGS := --triple wasm32-unknown-wasi
+else
+SWIFT_BUILD_FLAGS := --swift-sdk $(SWIFT_SDK_ID)
+endif
+
 .PHONY: bootstrap
 bootstrap:
 	npm ci
@@ -13,24 +19,24 @@ build:
 test:
 	@echo Running integration tests
 	cd IntegrationTests && \
-	    CONFIGURATION=debug make test && \
-	    CONFIGURATION=debug SWIFT_BUILD_FLAGS="-Xswiftc -DJAVASCRIPTKIT_WITHOUT_WEAKREFS" make test && \
-	    CONFIGURATION=release make test && \
-	    CONFIGURATION=release SWIFT_BUILD_FLAGS="-Xswiftc -DJAVASCRIPTKIT_WITHOUT_WEAKREFS" make test
+	    CONFIGURATION=debug   SWIFT_BUILD_FLAGS="$(SWIFT_BUILD_FLAGS)" $(MAKE) test && \
+	    CONFIGURATION=debug   SWIFT_BUILD_FLAGS="$(SWIFT_BUILD_FLAGS) -Xswiftc -DJAVASCRIPTKIT_WITHOUT_WEAKREFS" $(MAKE) test && \
+	    CONFIGURATION=release SWIFT_BUILD_FLAGS="$(SWIFT_BUILD_FLAGS)" $(MAKE) test && \
+	    CONFIGURATION=release SWIFT_BUILD_FLAGS="$(SWIFT_BUILD_FLAGS) -Xswiftc -DJAVASCRIPTKIT_WITHOUT_WEAKREFS" $(MAKE) test
 
 .PHONY: unittest
 unittest:
 	@echo Running unit tests
-	swift build --build-tests --triple wasm32-unknown-wasi -Xswiftc -Xclang-linker -Xswiftc -mexec-model=reactor -Xlinker --export-if-defined=main -Xlinker --export-if-defined=__main_argc_argv --static-swift-stdlib -Xswiftc -static-stdlib
+	swift build --build-tests -Xswiftc -Xclang-linker -Xswiftc -mexec-model=reactor -Xlinker --export-if-defined=main -Xlinker --export-if-defined=__main_argc_argv --static-swift-stdlib -Xswiftc -static-stdlib $(SWIFT_BUILD_FLAGS)
 	node --experimental-wasi-unstable-preview1 scripts/test-harness.mjs ./.build/wasm32-unknown-wasi/debug/JavaScriptKitPackageTests.wasm
 
 .PHONY: benchmark_setup
 benchmark_setup:
-	cd IntegrationTests && CONFIGURATION=release make benchmark_setup
+	SWIFT_BUILD_FLAGS="$(SWIFT_BUILD_FLAGS)" CONFIGURATION=release $(MAKE) -C IntegrationTests benchmark_setup
 
 .PHONY: run_benchmark
 run_benchmark:
-	cd IntegrationTests && CONFIGURATION=release make -s run_benchmark
+	SWIFT_BUILD_FLAGS="$(SWIFT_BUILD_FLAGS)" CONFIGURATION=release $(MAKE) -s -C IntegrationTests run_benchmark
 
 .PHONY: perf-tester
 perf-tester:


### PR DESCRIPTION
This is a preparation for https://github.com/swiftwasm/JavaScriptKit/pull/247 to test with thread-enabled SDK