### PR TITLE
Embedded Swift support [WIP]

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,39 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.10
 
 import PackageDescription
+
+let embeddedSwiftSettings: [SwiftSetting] = [
+    .enableExperimentalFeature("Embedded"),
+    .interoperabilityMode(.Cxx),
+    .unsafeFlags([
+        "-wmo", "-disable-cmo",
+        "-Xfrontend", "-gnone",
+        "-Xfrontend", "-disable-stack-protector",
+        "-Xfrontend", "-emit-empty-object-file"
+    ])
+]
+
+let embeddedCSettings: [CSetting] = [
+    .unsafeFlags(["-fdeclspec"])
+]
+
+let linkerSettings: [LinkerSetting] = [
+    .unsafeFlags([
+        "-Xclang-linker", "-nostdlib",
+        "-Xlinker", "--no-entry"
+    ])
+]
+
+let libcSettings: [CSetting] = [
+    .define("LACKS_TIME_H"),
+    .define("LACKS_SYS_TYPES_H"),
+    .define("LACKS_STDLIB_H"),
+    .define("LACKS_STRING_H"),
+    .define("LACKS_SYS_MMAN_H"),
+    .define("LACKS_FCNTL_H"),
+    .define("NO_MALLOC_STATS", to: "1"),
+    .define("__wasilibc_unmodified_upstream"),
+]
 
 let package = Package(
     name: "JavaScriptKit",
@@ -9,6 +42,14 @@ let package = Package(
         .library(name: "JavaScriptEventLoop", targets: ["JavaScriptEventLoop"]),
         .library(name: "JavaScriptBigIntSupport", targets: ["JavaScriptBigIntSupport"]),
         .library(name: "JavaScriptEventLoopTestSupport", targets: ["JavaScriptEventLoopTestSupport"]),
+        // Embedded
+        .library(name: "JavaScriptKitEmbedded", targets: ["JavaScriptKitEmbedded"]),
+        .library(name: "JavaScriptEventLoopEmbedded", targets: ["JavaScriptEventLoopEmbedded"]),
+        .library(name: "JavaScriptBigIntSupportEmbedded", targets: ["JavaScriptBigIntSupportEmbedded"]),
+        .library(name: "JavaScriptEventLoopTestSupportEmbedded", targets: ["JavaScriptEventLoopTestSupportEmbedded"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/swifweb/String16", branch: "0.1.0")
     ],
     targets: [
         .target(
@@ -36,11 +77,64 @@ let package = Package(
         ),
         .target(name: "_CJavaScriptEventLoopTestSupport"),
         .testTarget(
-          name: "JavaScriptEventLoopTestSupportTests",
-          dependencies: [
-            "JavaScriptKit",
-            "JavaScriptEventLoopTestSupport"
-          ]
+            name: "JavaScriptEventLoopTestSupportTests",
+            dependencies: [
+                "JavaScriptKit",
+                "JavaScriptEventLoopTestSupport"
+            ]
+        ),
+        // Embedded
+        .target(
+            name: "JavaScriptKitEmbedded",
+            dependencies: [
+                "_CJavaScriptKitEmbedded",
+                .product(name: "String16", package: "String16")
+            ],
+//            resources: [.copy("Runtime")], // FIXME: doesn't work with embedded because trying to import Foundation
+            cSettings: embeddedCSettings,
+            swiftSettings: embeddedSwiftSettings,
+            linkerSettings: linkerSettings
+        ),
+        .target(
+            name: "_CJavaScriptKitEmbedded",
+            cSettings: libcSettings
+        ),
+        .target(
+            name: "JavaScriptBigIntSupportEmbedded",
+            dependencies: ["_CJavaScriptBigIntSupportEmbedded", "JavaScriptKitEmbedded"],
+            cSettings: embeddedCSettings,
+            swiftSettings: embeddedSwiftSettings,
+            linkerSettings: linkerSettings
+        ),
+        .target(
+            name: "_CJavaScriptBigIntSupportEmbedded",
+            dependencies: ["_CJavaScriptKitEmbedded"],
+            cSettings: libcSettings
+        ),
+        .target(
+            name: "JavaScriptEventLoopEmbedded",
+            dependencies: ["JavaScriptKitEmbedded", "_CJavaScriptEventLoopEmbedded"],
+            cSettings: embeddedCSettings,
+            swiftSettings: embeddedSwiftSettings,
+            linkerSettings: linkerSettings
+        ),
+        .target(
+            name: "_CJavaScriptEventLoopEmbedded",
+            cSettings: libcSettings
+        ),
+        .target(
+            name: "JavaScriptEventLoopTestSupportEmbedded",
+            dependencies: [
+                "_CJavaScriptEventLoopTestSupportEmbedded",
+                "JavaScriptEventLoopEmbedded",
+            ],
+            cSettings: embeddedCSettings,
+            swiftSettings: embeddedSwiftSettings,
+            linkerSettings: linkerSettings
+        ),
+        .target(
+            name: "_CJavaScriptEventLoopTestSupportEmbedded",
+            cSettings: libcSettings
         ),
     ]
 )

--- a/Package@swift-5.7.swift
+++ b/Package@swift-5.7.swift
@@ -1,0 +1,46 @@
+// swift-tools-version:5.7
+
+import PackageDescription
+
+let package = Package(
+    name: "JavaScriptKit",
+    products: [
+        .library(name: "JavaScriptKit", targets: ["JavaScriptKit"]),
+        .library(name: "JavaScriptEventLoop", targets: ["JavaScriptEventLoop"]),
+        .library(name: "JavaScriptBigIntSupport", targets: ["JavaScriptBigIntSupport"]),
+        .library(name: "JavaScriptEventLoopTestSupport", targets: ["JavaScriptEventLoopTestSupport"]),
+    ],
+    targets: [
+        .target(
+            name: "JavaScriptKit",
+            dependencies: ["_CJavaScriptKit"],
+            resources: [.copy("Runtime")]
+        ),
+        .target(name: "_CJavaScriptKit"),
+        .target(
+            name: "JavaScriptBigIntSupport",
+            dependencies: ["_CJavaScriptBigIntSupport", "JavaScriptKit"]
+        ),
+        .target(name: "_CJavaScriptBigIntSupport", dependencies: ["_CJavaScriptKit"]),
+        .target(
+            name: "JavaScriptEventLoop",
+            dependencies: ["JavaScriptKit", "_CJavaScriptEventLoop"]
+        ),
+        .target(name: "_CJavaScriptEventLoop"),
+        .target(
+            name: "JavaScriptEventLoopTestSupport",
+            dependencies: [
+                "_CJavaScriptEventLoopTestSupport",
+                "JavaScriptEventLoop",
+            ]
+        ),
+        .target(name: "_CJavaScriptEventLoopTestSupport"),
+        .testTarget(
+          name: "JavaScriptEventLoopTestSupportTests",
+          dependencies: [
+            "JavaScriptKit",
+            "JavaScriptEventLoopTestSupport"
+          ]
+        ),
+    ]
+)

--- a/Runtime/src/types.ts
+++ b/Runtime/src/types.ts
@@ -49,7 +49,9 @@ export interface ImportedFunctions {
         payload2_ptr: pointer
     ): JavaScriptValueKind;
     swjs_encode_string(ref: number, bytes_ptr_result: pointer): number;
+    swjs_encode_utf16_string(ref: number, bytes_ptr_result: pointer): number;
     swjs_decode_string(bytes_ptr: pointer, length: number): number;
+    swjs_decode_utf16_string(bytes_ptr: pointer, length: number): number;
     swjs_load_string(ref: number, buffer: pointer): void;
     swjs_call_function(
         ref: number,

--- a/Sources/JavaScriptBigIntSupportEmbedded
+++ b/Sources/JavaScriptBigIntSupportEmbedded
@@ -1,0 +1,1 @@
+JavaScriptBigIntSupport

--- a/Sources/JavaScriptEventLoopEmbedded
+++ b/Sources/JavaScriptEventLoopEmbedded
@@ -1,0 +1,1 @@
+JavaScriptEventLoop

--- a/Sources/JavaScriptEventLoopTestSupportEmbedded
+++ b/Sources/JavaScriptEventLoopTestSupportEmbedded
@@ -1,0 +1,1 @@
+JavaScriptEventLoopTestSupport

--- a/Sources/JavaScriptKit/BasicObjects/JSDate.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSDate.swift
@@ -1,3 +1,7 @@
+#if hasFeature(Embedded)
+import String16
+#endif
+
 /** A wrapper around the [JavaScript `Date`
  class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) that
  exposes its properties in a type-safe way. This doesn't 100% match the JS API, for example
@@ -18,7 +22,11 @@ public final class JSDate: JSBridgedClass {
      */
     public init(millisecondsSinceEpoch: Double? = nil) {
         if let milliseconds = millisecondsSinceEpoch {
+            #if hasFeature(Embedded)
+            jsObject = Self.constructor!.new(milliseconds.jsValue)
+            #else
             jsObject = Self.constructor!.new(milliseconds)
+            #endif
         } else {
             jsObject = Self.constructor!.new()
         }
@@ -36,7 +44,11 @@ public final class JSDate: JSBridgedClass {
         seconds: Int = 0,
         milliseconds: Int = 0
     ) {
+        #if hasFeature(Embedded)
+        jsObject = Self.constructor!.new(year.jsValue, monthIndex.jsValue, day.jsValue, hours.jsValue, minutes.jsValue, seconds.jsValue, milliseconds.jsValue)
+        #else
         jsObject = Self.constructor!.new(year, monthIndex, day, hours, minutes, seconds, milliseconds)
+        #endif
     }
 
     public init(unsafelyWrapping jsObject: JSObject) {
@@ -49,7 +61,11 @@ public final class JSDate: JSBridgedClass {
             Int(jsObject.getFullYear!().number!)
         }
         set {
+            #if hasFeature(Embedded)
+            _ = jsObject.setFullYear!(newValue.jsValue)
+            #else
             _ = jsObject.setFullYear!(newValue)
+            #endif
         }
     }
 
@@ -59,7 +75,11 @@ public final class JSDate: JSBridgedClass {
             Int(jsObject.getMonth!().number!)
         }
         set {
+            #if hasFeature(Embedded)
+            _ = jsObject.setMonth!(newValue.jsValue)
+            #else
             _ = jsObject.setMonth!(newValue)
+            #endif
         }
     }
 
@@ -69,7 +89,11 @@ public final class JSDate: JSBridgedClass {
             Int(jsObject.getDate!().number!)
         }
         set {
+            #if hasFeature(Embedded)
+            _ = jsObject.setDate!(newValue.jsValue)
+            #else
             _ = jsObject.setDate!(newValue)
+            #endif
         }
     }
 
@@ -84,7 +108,11 @@ public final class JSDate: JSBridgedClass {
             Int(jsObject.getHours!().number!)
         }
         set {
+            #if hasFeature(Embedded)
+            _ = jsObject.setHours!(newValue.jsValue)
+            #else
             _ = jsObject.setHours!(newValue)
+            #endif
         }
     }
 
@@ -94,7 +122,11 @@ public final class JSDate: JSBridgedClass {
             Int(jsObject.getMinutes!().number!)
         }
         set {
+            #if hasFeature(Embedded)
+            _ = jsObject.setMinutes!(newValue.jsValue)
+            #else
             _ = jsObject.setMinutes!(newValue)
+            #endif
         }
     }
 
@@ -104,7 +136,11 @@ public final class JSDate: JSBridgedClass {
             Int(jsObject.getSeconds!().number!)
         }
         set {
+            #if hasFeature(Embedded)
+            _ = jsObject.setSeconds!(newValue.jsValue)
+            #else
             _ = jsObject.setSeconds!(newValue)
+            #endif
         }
     }
 
@@ -114,7 +150,11 @@ public final class JSDate: JSBridgedClass {
             Int(jsObject.getMilliseconds!().number!)
         }
         set {
+            #if hasFeature(Embedded)
+            _ = jsObject.setMilliseconds!(newValue.jsValue)
+            #else
             _ = jsObject.setMilliseconds!(newValue)
+            #endif
         }
     }
 
@@ -124,7 +164,11 @@ public final class JSDate: JSBridgedClass {
             Int(jsObject.getUTCFullYear!().number!)
         }
         set {
+            #if hasFeature(Embedded)
+            _ = jsObject.setUTCFullYear!(newValue.jsValue)
+            #else
             _ = jsObject.setUTCFullYear!(newValue)
+            #endif
         }
     }
 
@@ -134,7 +178,11 @@ public final class JSDate: JSBridgedClass {
             Int(jsObject.getUTCMonth!().number!)
         }
         set {
+            #if hasFeature(Embedded)
+            _ = jsObject.setUTCMonth!(newValue.jsValue)
+            #else
             _ = jsObject.setUTCMonth!(newValue)
+            #endif
         }
     }
 
@@ -144,7 +192,11 @@ public final class JSDate: JSBridgedClass {
             Int(jsObject.getUTCDate!().number!)
         }
         set {
+            #if hasFeature(Embedded)
+            _ = jsObject.setUTCDate!(newValue.jsValue)
+            #else
             _ = jsObject.setUTCDate!(newValue)
+            #endif
         }
     }
 
@@ -159,7 +211,11 @@ public final class JSDate: JSBridgedClass {
             Int(jsObject.getUTCHours!().number!)
         }
         set {
+            #if hasFeature(Embedded)
+            _ = jsObject.setUTCHours!(newValue.jsValue)
+            #else
             _ = jsObject.setUTCHours!(newValue)
+            #endif
         }
     }
 
@@ -169,7 +225,11 @@ public final class JSDate: JSBridgedClass {
             Int(jsObject.getUTCMinutes!().number!)
         }
         set {
+            #if hasFeature(Embedded)
+            _ = jsObject.setUTCMinutes!(newValue.jsValue)
+            #else
             _ = jsObject.setUTCMinutes!(newValue)
+            #endif
         }
     }
 
@@ -179,7 +239,11 @@ public final class JSDate: JSBridgedClass {
             Int(jsObject.getUTCSeconds!().number!)
         }
         set {
+            #if hasFeature(Embedded)
+            _ = jsObject.setUTCSeconds!(newValue.jsValue)
+            #else
             _ = jsObject.setUTCSeconds!(newValue)
+            #endif
         }
     }
 
@@ -189,7 +253,11 @@ public final class JSDate: JSBridgedClass {
             Int(jsObject.getUTCMilliseconds!().number!)
         }
         set {
+            #if hasFeature(Embedded)
+            _ = jsObject.setUTCMilliseconds!(newValue.jsValue)
+            #else
             _ = jsObject.setUTCMilliseconds!(newValue)
+            #endif
         }
     }
 
@@ -200,28 +268,52 @@ public final class JSDate: JSBridgedClass {
 
     /// Returns a string conforming to ISO 8601 that contains date and time, e.g.
     /// `"2020-09-15T08:56:54.811Z"`.
+    #if hasFeature(Embedded)
+    public func toISOString() -> String16 {
+        jsObject.toISOString!().string!
+    }
+    #else
     public func toISOString() -> String {
         jsObject.toISOString!().string!
     }
+    #endif
 
     /// Returns a string with date parts in a format defined by user's locale, e.g. `"9/15/2020"`.
+    #if hasFeature(Embedded)
+    public func toLocaleDateString() -> String16 {
+        jsObject.toLocaleDateString!().string!
+    }
+    #else
     public func toLocaleDateString() -> String {
         jsObject.toLocaleDateString!().string!
     }
+    #endif
 
     /// Returns a string with time parts in a format defined by user's locale, e.g. `"10:04:14"`.
+    #if hasFeature(Embedded)
+    public func toLocaleTimeString() -> String16 {
+        jsObject.toLocaleTimeString!().string!
+    }
+    #else
     public func toLocaleTimeString() -> String {
         jsObject.toLocaleTimeString!().string!
     }
+    #endif
 
     /** Returns a string formatted according to
      [rfc7231](https://tools.ietf.org/html/rfc7231#section-7.1.1.1) and modified according to
      [ecma-262](https://www.ecma-international.org/ecma-262/10.0/index.html#sec-date.prototype.toutcstring),
      e.g. `Tue, 15 Sep 2020 09:04:40 GMT`.
      */
+    #if hasFeature(Embedded)
+    public func toUTCString() -> String16 {
+        jsObject.toUTCString!().string!
+    }
+    #else
     public func toUTCString() -> String {
         jsObject.toUTCString!().string!
     }
+    #endif
 
     /** Number of milliseconds since midnight 01 January 1970 UTC to the present moment ignoring
      leap seconds.

--- a/Sources/JavaScriptKit/BasicObjects/JSError.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSError.swift
@@ -1,3 +1,7 @@
+#if hasFeature(Embedded)
+import String16
+#endif
+
 /** A wrapper around [the JavaScript `Error`
  class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) that
  exposes its properties in a type-safe way.
@@ -10,28 +14,52 @@ public final class JSError: Error, JSBridgedClass {
     public let jsObject: JSObject
 
     /// Creates a new instance of the JavaScript `Error` class with a given message.
+    #if hasFeature(Embedded)
+    public init(message: String16) {
+        jsObject = Self.constructor!.new(arguments: [JSString(message).jsValue])
+    }
+    #else
     public init(message: String) {
         jsObject = Self.constructor!.new([message])
     }
+    #endif
 
     public init(unsafelyWrapping jsObject: JSObject) {
         self.jsObject = jsObject
     }
 
     /// The error message of the underlying `Error` object.
+    #if hasFeature(Embedded)
+    public var message: String16 {
+        jsObject.message.string!
+    }
+    #else
     public var message: String {
         jsObject.message.string!
     }
+    #endif
 
     /// The name (usually corresponds to the name of the underlying class) of a given error.
+    #if hasFeature(Embedded)
+    public var name: String16 {
+        jsObject.name.string!
+    }
+    #else
     public var name: String {
         jsObject.name.string!
     }
+    #endif
 
     /// The JavaScript call stack that led to the creation of this error object.
+    #if hasFeature(Embedded)
+    public var stack: String16? {
+        jsObject.stack.string
+    }
+    #else
     public var stack: String? {
         jsObject.stack.string
     }
+    #endif
 
     /// Creates a new `JSValue` from this `JSError` instance.
     public var jsValue: JSValue {
@@ -41,5 +69,9 @@ public final class JSError: Error, JSBridgedClass {
 
 extension JSError: CustomStringConvertible {
     /// The textual representation of this error.
+    #if hasFeature(Embedded)
+    public var description: String16 { jsObject.description }
+    #else
     public var description: String { jsObject.description }
+    #endif
 }

--- a/Sources/JavaScriptKit/ConstructibleFromJSValue.swift
+++ b/Sources/JavaScriptKit/ConstructibleFromJSValue.swift
@@ -1,3 +1,7 @@
+#if hasFeature(Embedded)
+import String16
+#endif
+
 /// Types conforming to this protocol can be constructed from `JSValue`.
 public protocol ConstructibleFromJSValue {
     /// Construct an instance of `Self`, if possible, from the given `JSValue`.
@@ -14,11 +18,19 @@ extension Bool: ConstructibleFromJSValue {
     }
 }
 
+#if hasFeature(Embedded)
+extension String16: ConstructibleFromJSValue {
+    public static func construct(from value: JSValue) -> String16? {
+        value.string
+    }
+}
+#else
 extension String: ConstructibleFromJSValue {
     public static func construct(from value: JSValue) -> String? {
         value.string
     }
 }
+#endif
 
 extension JSString: ConstructibleFromJSValue {
     public static func construct(from value: JSValue) -> JSString? {
@@ -35,16 +47,21 @@ extension Double: ConstructibleFromJSValue {}
 extension Float: ConstructibleFromJSValue {}
 
 extension SignedInteger where Self: ConstructibleFromJSValue {
+    #if !hasFeature(Embedded)
     public init(_ bigInt: JSBigIntExtended) {
         self.init(bigInt.int64Value)
     }
+    #endif
+
     public static func construct(from value: JSValue) -> Self? {
         if let number = value.number {
             return Self(number)
         }
+        #if !hasFeature(Embedded)
         if let bigInt = value.bigInt as? JSBigIntExtended {
             return Self(bigInt)
         }
+        #endif
         return nil
     }
 }
@@ -55,16 +72,20 @@ extension Int32: ConstructibleFromJSValue {}
 extension Int64: ConstructibleFromJSValue {}
 
 extension UnsignedInteger where Self: ConstructibleFromJSValue {
+    #if !hasFeature(Embedded)
     public init(_ bigInt: JSBigIntExtended) {
         self.init(bigInt.uInt64Value)
     }
+    #endif
     public static func construct(from value: JSValue) -> Self? {
         if let number = value.number {
             return Self(number)
         }
+        #if !hasFeature(Embedded)
         if let bigInt = value.bigInt as? JSBigIntExtended {
             return Self(bigInt)
         }
+        #endif
         return nil
     }
 }

--- a/Sources/JavaScriptKit/ConvertibleToJSValue.swift
+++ b/Sources/JavaScriptKit/ConvertibleToJSValue.swift
@@ -334,7 +334,7 @@ extension JSValue {
             payload1 = boolValue ? 1 : 0
         case let .number(numberValue):
             #if hasFeature(Embedded)
-            kind = 1
+            kind = 2
             #else
             kind = .number
             #endif
@@ -344,42 +344,42 @@ extension JSValue {
             return string.withRawJSValue(body)
         case let .object(ref):
             #if hasFeature(Embedded)
-            kind = 2
+            kind = 3
             #else
             kind = .object
             #endif
             payload1 = JavaScriptPayload1(ref.id)
         case .null:
             #if hasFeature(Embedded)
-            kind = 3
+            kind = 4
             #else
             kind = .null
             #endif
             payload1 = 0
         case .undefined:
             #if hasFeature(Embedded)
-            kind = 4
+            kind = 5
             #else
             kind = .undefined
             #endif
             payload1 = 0
         case let .function(functionRef):
             #if hasFeature(Embedded)
-            kind = 5
+            kind = 6
             #else
             kind = .function
             #endif
             payload1 = JavaScriptPayload1(functionRef.id)
         case let .symbol(symbolRef):
             #if hasFeature(Embedded)
-            kind = 6
+            kind = 7
             #else
             kind = .symbol
             #endif
             payload1 = JavaScriptPayload1(symbolRef.id)
         case let .bigInt(bigIntRef):
             #if hasFeature(Embedded)
-            kind = 7
+            kind = 8
             #else
             kind = .bigInt
             #endif

--- a/Sources/JavaScriptKit/Deprecated.swift
+++ b/Sources/JavaScriptKit/Deprecated.swift
@@ -1,3 +1,4 @@
+#if !hasFeature(Embedded)
 @available(*, deprecated, renamed: "JSObject")
 public typealias JSObjectRef = JSObject
 
@@ -15,3 +16,4 @@ public typealias JSValueConstructible = ConstructibleFromJSValue
 
 @available(*, deprecated, renamed: "JSValueCompatible")
 public typealias JSValueCodable = JSValueCompatible
+#endif

--- a/Sources/JavaScriptKit/Features.swift
+++ b/Sources/JavaScriptKit/Features.swift
@@ -3,7 +3,7 @@ enum LibraryFeatures {
 }
 
 @_cdecl("_library_features")
-func _library_features() -> Int32 {
+public func _library_features() -> Int32 { // FIXME: it's public because _cdecl isn't visible outside in Embedded Swift
     var features: Int32 = 0
 #if !JAVASCRIPTKIT_WITHOUT_WEAKREFS
     features |= LibraryFeatures.weakRefs

--- a/Sources/JavaScriptKit/FundamentalObjects/JSBigInt.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSBigInt.swift
@@ -30,9 +30,17 @@ public final class JSBigInt: JSObject {
 
     public func clamped(bitSize: Int, signed: Bool) -> JSBigInt {
         if signed {
+            #if hasFeature(Embedded)
+            return constructor.asIntN!(bitSize.jsValue, self.jsValue).bigInt!
+            #else
             return constructor.asIntN!(bitSize, self).bigInt!
+            #endif
         } else {
+            #if hasFeature(Embedded)
+            return constructor.asUintN!(bitSize.jsValue, self.jsValue).bigInt!
+            #else
             return constructor.asUintN!(bitSize, self).bigInt!
+            #endif
         }
     }
 }

--- a/Sources/JavaScriptKit/FundamentalObjects/JSString.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSString.swift
@@ -1,5 +1,107 @@
+#if hasFeature(Embedded)
+import String16
+import Foundation
+#endif
 import _CJavaScriptKit
 
+#if hasFeature(Embedded)
+/// `JSString` represents a string in JavaScript and supports bridging string between JavaScript and Swift.
+///
+/// Conversion between `String16` and `JSString` can be:
+///
+/// ```swift
+/// // Convert `String16` to `JSString`
+/// let jsString: JSString = ...
+/// let swiftString: String = String(jsString)
+///
+/// // Convert `JSString` to `String16`
+/// let swiftString: String = ...
+/// let jsString: JSString = JSString(swiftString)
+/// ```
+///
+public struct JSString: CustomStringConvertible, Equatable {
+    /// The internal representation of JS compatible string
+    /// The initializers of this type must initialize `jsRef` or `buffer`.
+    /// And the uninitialized one will be lazily initialized
+    class Guts {
+        var shouldDealocateRef: Bool = false
+        lazy var jsRef: JavaScriptObjectRef = {
+            self.shouldDealocateRef = true
+            let intRepresentation = Int(bitPattern: buffer.pointer)
+            return _decode_string(Int32(intRepresentation), Int32(buffer.bytesCount))
+        }()
+
+        lazy var buffer: String16 = {
+            var bytesRef: JavaScriptObjectRef = 0
+            let bytesLength = Int(_encode_string(jsRef, &bytesRef))
+            // +1 for null terminator
+            let buffer = __malloc(Int(bytesLength + 1)).assumingMemoryBound(to: UInt8.self)
+            defer {
+                __free(buffer)
+                _release(bytesRef)
+            }
+            _load_string(bytesRef, buffer)
+            buffer[bytesLength] = 0
+            return .init(bytesCount: bytesLength, pointer: buffer)
+        }()
+
+        init(from stringValue: String16) {
+            self.buffer = stringValue
+        }
+
+        init(from jsRef: JavaScriptObjectRef) {
+            self.jsRef = jsRef
+            self.shouldDealocateRef = true
+        }
+
+        deinit {
+            guard shouldDealocateRef else { return }
+            _release(jsRef)
+        }
+    }
+
+    let guts: Guts
+    
+    var string16: String16 { guts.buffer }
+
+    internal init(jsRef: JavaScriptObjectRef) {
+        self.guts = Guts(from: jsRef)
+    }
+
+    /// Instantiate a new `JSString` with given UTF-16 String.
+    public init(_ stringValue: String16) {
+        self.guts = Guts(from: stringValue)
+    }
+    
+    /// A Swift representation of this `JSString`.
+    /// Note that this accessor may copy the JS string value into Swift side memory.
+    public var description: String16 { guts.buffer }
+
+    /// Returns a Boolean value indicating whether two strings are equal values.
+    ///
+    /// - Parameters:
+    ///   - lhs: A string to compare.
+    ///   - rhs: Another string to compare.
+    public static func == (lhs: JSString, rhs: JSString) -> Bool {
+        return lhs.guts.buffer == rhs.guts.buffer
+    }
+}
+
+// MARK: - Internal Helpers
+extension JSString {
+
+    func asInternalJSRef() -> JavaScriptObjectRef {
+        guts.jsRef
+    }
+
+    func withRawJSValue<T>(_ body: (RawJSValue) -> T) -> T {
+        let rawValue = RawJSValue(
+            kind: 1, payload1: guts.jsRef, payload2: 0
+        )
+        return body(rawValue)
+    }
+}
+#else
 /// `JSString` represents a string in JavaScript and supports bridging string between JavaScript and Swift.
 ///
 /// Conversion between `Swift.String` and `JSString` can be:
@@ -87,7 +189,6 @@ extension JSString: ExpressibleByStringLiteral {
     }
 }
 
-
 // MARK: - Internal Helpers
 extension JSString {
 
@@ -102,3 +203,4 @@ extension JSString {
         return body(rawValue)
     }
 }
+#endif

--- a/Sources/JavaScriptKit/FundamentalObjects/JSSymbol.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSSymbol.swift
@@ -1,4 +1,7 @@
 import _CJavaScriptKit
+#if hasFeature(Embedded)
+import String16
+#endif
 
 private let Symbol = JSObject.global.Symbol.function!
 
@@ -6,40 +9,81 @@ private let Symbol = JSObject.global.Symbol.function!
 /// class](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol)
 /// that exposes its properties in a type-safe and Swifty way.
 public class JSSymbol: JSObject {
+    #if hasFeature(Embedded)
+    public var name: String16? { self["description"].string }
+    #else
     public var name: String? { self["description"].string }
+    #endif
 
+    #if hasFeature(Embedded)
+    public init(_ description: JSString) {
+        // can’t do `self =` so we have to get the ID manually
+        let result = Symbol.invokeNonThrowingJSFunction(arguments: [description.jsValue])
+        precondition(result.kind == 7)
+        super.init(id: UInt32(result.payload1))
+    }
+    #else
     public init(_ description: JSString) {
         // can’t do `self =` so we have to get the ID manually
         let result = Symbol.invokeNonThrowingJSFunction(arguments: [description])
         precondition(result.kind == .symbol)
         super.init(id: UInt32(result.payload1))
     }
+    #endif
+    #if hasFeature(Embedded)
+    @_disfavoredOverload
+    public convenience init(_ description: String16) {
+        self.init(JSString(description))
+    }
+    #else
     @_disfavoredOverload
     public convenience init(_ description: String) {
         self.init(JSString(description))
     }
+    #endif
 
     override init(id: JavaScriptObjectRef) {
         super.init(id: id)
     }
 
     public static func `for`(key: JSString) -> JSSymbol {
+        #if hasFeature(Embedded)
+        Symbol.for!(key.jsValue).symbol!
+        #else
         Symbol.for!(key).symbol!
+        #endif
     }
-
+    #if hasFeature(Embedded)
+    @_disfavoredOverload
+    public static func `for`(key: String16) -> JSSymbol {
+        Symbol.for!(key.jsValue).symbol!
+    }
+    #else
     @_disfavoredOverload
     public static func `for`(key: String) -> JSSymbol {
         Symbol.for!(key).symbol!
     }
+    #endif
 
     public static func key(for symbol: JSSymbol) -> JSString? {
+        #if hasFeature(Embedded)
+        Symbol.keyFor!(symbol.jsValue).jsString
+        #else
         Symbol.keyFor!(symbol).jsString
+        #endif
     }
 
+    #if hasFeature(Embedded)
+    @_disfavoredOverload
+    public static func key(for symbol: JSSymbol) -> String16? {
+        Symbol.keyFor!(symbol.jsValue).string
+    }
+    #else
     @_disfavoredOverload
     public static func key(for symbol: JSSymbol) -> String? {
         Symbol.keyFor!(symbol).string
     }
+    #endif
 
     override public var jsValue: JSValue {
         .symbol(self)

--- a/Sources/JavaScriptKit/JSBridgedType.swift
+++ b/Sources/JavaScriptKit/JSBridgedType.swift
@@ -1,3 +1,7 @@
+#if hasFeature(Embedded)
+import String16
+#endif
+
 /// Use this protocol when your type has no single JavaScript class.
 /// For example, a union type of multiple classes or primitive values.
 public protocol JSBridgedType: JSValueCompatible, CustomStringConvertible {
@@ -9,8 +13,11 @@ public extension JSBridgedType {
     static func construct(from value: JSValue) -> Self? {
         Self(from: value)
     }
-
+    #if hasFeature(Embedded)
+    var description: String16 { jsValue.description }
+    #else
     var description: String { jsValue.description }
+    #endif
 }
 
 /// Conform to this protocol when your Swift class wraps a JavaScript class.

--- a/Sources/JavaScriptKit/JSValueDecoder.swift
+++ b/Sources/JavaScriptKit/JSValueDecoder.swift
@@ -1,3 +1,4 @@
+#if !hasFeature(Embedded)
 private struct _Decoder: Decoder {
     fileprivate let node: JSValue
 
@@ -248,3 +249,4 @@ public class JSValueDecoder {
         return try T(from: decoder)
     }
 }
+#endif

--- a/Sources/JavaScriptKitEmbedded
+++ b/Sources/JavaScriptKitEmbedded
@@ -1,0 +1,1 @@
+JavaScriptKit

--- a/Sources/_CJavaScriptBigIntSupportEmbedded
+++ b/Sources/_CJavaScriptBigIntSupportEmbedded
@@ -1,0 +1,1 @@
+_CJavaScriptBigIntSupport

--- a/Sources/_CJavaScriptEventLoopEmbedded
+++ b/Sources/_CJavaScriptEventLoopEmbedded
@@ -1,0 +1,1 @@
+_CJavaScriptEventLoop

--- a/Sources/_CJavaScriptEventLoopTestSupportEmbedded
+++ b/Sources/_CJavaScriptEventLoopTestSupportEmbedded
@@ -1,0 +1,1 @@
+_CJavaScriptEventLoopTestSupport

--- a/Sources/_CJavaScriptKit/_CJavaScriptKit.c
+++ b/Sources/_CJavaScriptKit/_CJavaScriptKit.c
@@ -1,8 +1,18 @@
 #include "_CJavaScriptKit.h"
+#if __wasm32__
+#if __Embedded
+#if __has_include("malloc.h")
+#include <malloc.h>
+#endif
+extern void *malloc(size_t size);
+extern void free(void *ptr);
+extern void *memset (void *, int, size_t);
+extern void *memcpy (void *__restrict, const void *__restrict, size_t);
+#else
 #include <stdlib.h>
 #include <stdbool.h>
 
-#if __wasm32__
+#endif
 
 bool _call_host_function_impl(const JavaScriptHostFuncRef host_func_ref,
                               const RawJSValue *argv, const int argc,

--- a/Sources/_CJavaScriptKit/include/_CJavaScriptKit.h
+++ b/Sources/_CJavaScriptKit/include/_CJavaScriptKit.h
@@ -1,7 +1,12 @@
 #ifndef _CJavaScriptKit_h
 #define _CJavaScriptKit_h
 
+#if __Embedded
+#include <stddef.h>
+#else
 #include <stdlib.h>
+#endif
+
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -25,10 +30,17 @@ typedef enum __attribute__((enum_extensibility(closed))) {
   JavaScriptValueKindBigInt = 8,
 } JavaScriptValueKind;
 
+#if __Embedded
+typedef struct {
+  unsigned long kind: 4;
+  bool isException: 1;
+} JavaScriptValueKindAndFlags;
+#else
 typedef struct {
   JavaScriptValueKind kind: 31;
   bool isException: 1;
 } JavaScriptValueKindAndFlags;
+#endif
 
 typedef unsigned JavaScriptPayload1;
 typedef double JavaScriptPayload2;
@@ -66,11 +78,19 @@ typedef double JavaScriptPayload2;
 ///    payload1: `JavaScriptObjectRef`
 ///    payload2: 0
 ///
+#if __Embedded
+typedef struct {
+  unsigned long kind;
+  JavaScriptPayload1 payload1;
+  JavaScriptPayload2 payload2;
+} RawJSValue;
+#else
 typedef struct {
   JavaScriptValueKind kind;
   JavaScriptPayload1 payload1;
   JavaScriptPayload2 payload2;
 } RawJSValue;
+#endif
 
 #if __wasm32__
 
@@ -81,6 +101,15 @@ typedef struct {
 /// @param kind A kind of JavaScript value to set the target object.
 /// @param payload1 The first payload of JavaScript value to set the target object.
 /// @param payload2 The second payload of JavaScript value to set the target object.
+#if __Embedded
+__attribute__((__import_module__("javascript_kit"),
+               __import_name__("swjs_set_prop")))
+extern void _set_prop(const JavaScriptObjectRef _this,
+                      const JavaScriptObjectRef prop,
+                      const unsigned long kind,
+                      const JavaScriptPayload1 payload1,
+                      const JavaScriptPayload2 payload2);
+#else
 __attribute__((__import_module__("javascript_kit"),
                __import_name__("swjs_set_prop")))
 extern void _set_prop(const JavaScriptObjectRef _this,
@@ -88,6 +117,7 @@ extern void _set_prop(const JavaScriptObjectRef _this,
                       const JavaScriptValueKind kind,
                       const JavaScriptPayload1 payload1,
                       const JavaScriptPayload2 payload2);
+#endif
 
 /// `_get_prop` gets a value of `_this` JavaScript object.
 ///
@@ -112,6 +142,15 @@ extern uint32_t _get_prop(
 /// @param kind A kind of JavaScript value to set the target object.
 /// @param payload1 The first payload of JavaScript value to set the target object.
 /// @param payload2 The second payload of JavaScript value to set the target object.
+#if __Embedded
+__attribute__((__import_module__("javascript_kit"),
+               __import_name__("swjs_set_subscript")))
+extern void _set_subscript(const JavaScriptObjectRef _this,
+                           const int index,
+                           const unsigned long kind,
+                           const JavaScriptPayload1 payload1,
+                           const JavaScriptPayload2 payload2);
+#else
 __attribute__((__import_module__("javascript_kit"),
                __import_name__("swjs_set_subscript")))
 extern void _set_subscript(const JavaScriptObjectRef _this,
@@ -119,6 +158,7 @@ extern void _set_subscript(const JavaScriptObjectRef _this,
                            const JavaScriptValueKind kind,
                            const JavaScriptPayload1 payload1,
                            const JavaScriptPayload2 payload2);
+#endif
 
 /// `_get_subscript` gets a value of `_this` JavaScript object.
 ///
@@ -151,9 +191,15 @@ extern int _encode_string(const JavaScriptObjectRef str_obj, JavaScriptObjectRef
 /// @param bytes_ptr A `uint8_t` byte sequence to decode.
 /// @param length The length of `bytes_ptr`.
 /// @result The decoded JavaScript string object.
+#if __Embedded
+__attribute__((__import_module__("javascript_kit"),
+               __import_name__("swjs_decode_string")))
+extern JavaScriptObjectRef _decode_string(const int pointer, const int length);
+#else
 __attribute__((__import_module__("javascript_kit"),
                __import_name__("swjs_decode_string")))
 extern JavaScriptObjectRef _decode_string(const unsigned char *bytes_ptr, const int length);
+#endif
 
 /// `_load_string` loads the actual bytes sequence of `bytes` into `buffer` which is a Swift side memory address.
 ///
@@ -265,6 +311,15 @@ extern JavaScriptObjectRef _call_new(const JavaScriptObjectRef ref,
 /// @param exception_payload1 A result pointer of first payload of JavaScript value of thrown exception.
 /// @param exception_payload2 A result pointer of second payload of JavaScript value of thrown exception.
 /// @returns A reference to the constructed object.
+#if __Embedded
+__attribute__((__import_module__("javascript_kit"),
+               __import_name__("swjs_call_throwing_new")))
+extern JavaScriptObjectRef _call_throwing_new(const JavaScriptObjectRef ref,
+                                              const RawJSValue *argv, const int argc,
+                                              uint32_t *exception_kind,
+                                              JavaScriptPayload1 *exception_payload1,
+                                              JavaScriptPayload2 *exception_payload2);
+#else
 __attribute__((__import_module__("javascript_kit"),
                __import_name__("swjs_call_throwing_new")))
 extern JavaScriptObjectRef _call_throwing_new(const JavaScriptObjectRef ref,
@@ -272,6 +327,7 @@ extern JavaScriptObjectRef _call_throwing_new(const JavaScriptObjectRef ref,
                                               JavaScriptValueKindAndFlags *exception_kind,
                                               JavaScriptPayload1 *exception_payload1,
                                               JavaScriptPayload2 *exception_payload2);
+#endif
 
 /// `_instanceof` acts like JavaScript `instanceof` operator.
 ///

--- a/Sources/_CJavaScriptKitEmbedded
+++ b/Sources/_CJavaScriptKitEmbedded
@@ -1,0 +1,1 @@
+_CJavaScriptKit


### PR DESCRIPTION
It adds an ability to use the original `JavaScriptKit` in Embedded Swift

All the targets has been copied with `Embedded` suffix and uses the original source code via symlinks in order to have an ability to add special flags for Embedded Swift.

[String16](https://github.com/swifweb/String16) library has been written with an absolute minimal working code at this moment in order to provide UTF-16 String replacement for Embedded Swift. 

[EmbeddedFoundation](https://github.com/swifweb/EmbeddedFoundation) library provides `malloc`, `free`, `arc4rand` methods for Embedded Swift.

~~What's not working currently: `JSClosure`, `JSOneShotClosure`. It seems I missing something. Investigating what's wrong.~~ 

[LightWebApp](https://github.com/swifweb/LightWebApp) is a demo Embedded Swift project which uses this version of `JavaScriptKit`.