### PR TITLE
Allocate JavaScriptEventLoop per thread in multi-threaded environment 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,11 @@ jobs:
           - { os: ubuntu-22.04, toolchain: wasm-5.10.0-RELEASE, wasi-backend: Node }
 
           # Ensure that test succeeds with all toolchains and wasi backend combinations
-          - { os: ubuntu-20.04, toolchain: wasm-5.7.3-RELEASE, wasi-backend: Node }
           - { os: ubuntu-20.04, toolchain: wasm-5.8.0-RELEASE, wasi-backend: Node }
-          - { os: ubuntu-20.04, toolchain: wasm-5.7.3-RELEASE, wasi-backend: MicroWASI }
+          - { os: ubuntu-20.04, toolchain: wasm-5.10.0-RELEASE, wasi-backend: Node }
           - { os: ubuntu-20.04, toolchain: wasm-5.8.0-RELEASE, wasi-backend: MicroWASI }
           - { os: ubuntu-20.04, toolchain: wasm-5.9.1-RELEASE, wasi-backend: MicroWASI }
+          - { os: ubuntu-20.04, toolchain: wasm-5.10.0-RELEASE, wasi-backend: MicroWASI }
           - os: ubuntu-22.04
             toolchain: DEVELOPMENT-SNAPSHOT-2024-05-01-a
             swift-sdk:
@@ -76,8 +76,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-12
-            xcode: Xcode_14.0
           - os: macos-13
             xcode: Xcode_14.3
           - os: macos-14

--- a/Sources/JavaScriptEventLoop/JavaScriptEventLoop.swift
+++ b/Sources/JavaScriptEventLoop/JavaScriptEventLoop.swift
@@ -61,7 +61,7 @@ public final class JavaScriptEventLoop: SerialExecutor, @unchecked Sendable {
         return _shared
     }
 
-    #if _runtime(_multithreaded)
+    #if compiler(>=6.0) && _runtime(_multithreaded)
     // In multi-threaded environment, we have an event loop executor per
     // thread (per Web Worker). A job enqueued in one thread should be
     // executed in the same thread under this global executor.

--- a/Sources/JavaScriptEventLoop/JavaScriptEventLoop.swift
+++ b/Sources/JavaScriptEventLoop/JavaScriptEventLoop.swift
@@ -103,10 +103,6 @@ public final class JavaScriptEventLoop: SerialExecutor, @unchecked Sendable {
     }
 
     private static var didInstallGlobalExecutor = false
-    fileprivate static var _mainThreadEventLoop: JavaScriptEventLoop!
-    fileprivate static var mainThreadEventLoop: JavaScriptEventLoop {
-        return _mainThreadEventLoop
-    }
 
     /// Set JavaScript event loop based executor to be the global executor
     /// Note that this should be called before any of the jobs are created.
@@ -115,10 +111,6 @@ public final class JavaScriptEventLoop: SerialExecutor, @unchecked Sendable {
     /// executors](https://github.com/rjmccall/swift-evolution/blob/custom-executors/proposals/0000-custom-executors.md#the-default-global-concurrent-executor)
     public static func installGlobalExecutor() {
         guard !didInstallGlobalExecutor else { return }
-
-        // NOTE: We assume that this function is called before any of the jobs are created, so we can safely
-        // assume that we are in the main thread.
-        _mainThreadEventLoop = JavaScriptEventLoop.shared
 
         #if compiler(>=5.9)
         typealias swift_task_asyncMainDrainQueue_hook_Fn = @convention(thin) (swift_task_asyncMainDrainQueue_original, swift_task_asyncMainDrainQueue_override) -> Void

--- a/Sources/JavaScriptEventLoop/JavaScriptEventLoop.swift
+++ b/Sources/JavaScriptEventLoop/JavaScriptEventLoop.swift
@@ -150,7 +150,7 @@ public final class JavaScriptEventLoop: SerialExecutor, @unchecked Sendable {
 
         typealias swift_task_enqueueMainExecutor_hook_Fn = @convention(thin) (UnownedJob, swift_task_enqueueMainExecutor_original) -> Void
         let swift_task_enqueueMainExecutor_hook_impl: swift_task_enqueueMainExecutor_hook_Fn = { job, original in
-            JavaScriptEventLoop.enqueueMainJob(job)
+            JavaScriptEventLoop.shared.unsafeEnqueue(job)
         }
         swift_task_enqueueMainExecutor_hook = unsafeBitCast(swift_task_enqueueMainExecutor_hook_impl, to: UnsafeMutableRawPointer?.self)
 
@@ -187,21 +187,6 @@ public final class JavaScriptEventLoop: SerialExecutor, @unchecked Sendable {
 
     public func asUnownedSerialExecutor() -> UnownedSerialExecutor {
         return UnownedSerialExecutor(ordinary: self)
-    }
-
-    public static func enqueueMainJob(_ job: consuming ExecutorJob) {
-        self.enqueueMainJob(UnownedJob(job))
-    }
-
-    static func enqueueMainJob(_ job: UnownedJob) {
-        let currentEventLoop = JavaScriptEventLoop.shared
-        if currentEventLoop === JavaScriptEventLoop.mainThreadEventLoop {
-            currentEventLoop.unsafeEnqueue(job)
-        } else {
-            // Notify the main thread to execute the job
-            let jobBitPattern = unsafeBitCast(job, to: UInt.self)
-            _ = JSObject.global.postMessage!(jobBitPattern)
-        }
     }
 }
 

--- a/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
@@ -137,7 +137,16 @@ public class JSObject: Equatable {
 
     /// A `JSObject` of the global scope object.
     /// This allows access to the global properties and global names by accessing the `JSObject` returned.
-    public static let global = JSObject(id: _JS_Predef_Value_Global)
+    public static var global: JSObject { return _global }
+
+    // `JSObject` storage itself is immutable, and use of `JSObject.global` from other
+    // threads maintains the same semantics as `globalThis` in JavaScript.
+    #if compiler(>=5.10)
+    nonisolated(unsafe)
+    static let _global = JSObject(id: _JS_Predef_Value_Global)
+    #else
+    static let _global = JSObject(id: _JS_Predef_Value_Global)
+    #endif
 
     deinit { swjs_release(id) }
 

--- a/Sources/_CJavaScriptEventLoop/_CJavaScriptEventLoop.c
+++ b/Sources/_CJavaScriptEventLoop/_CJavaScriptEventLoop.c
@@ -1,0 +1,3 @@
+#include "_CJavaScriptEventLoop.h"
+
+_Thread_local void *swjs_thread_local_event_loop;

--- a/Sources/_CJavaScriptEventLoop/include/_CJavaScriptEventLoop.h
+++ b/Sources/_CJavaScriptEventLoop/include/_CJavaScriptEventLoop.h
@@ -61,4 +61,9 @@ typedef SWIFT_CC(swift) void (*swift_task_asyncMainDrainQueue_override)(
 SWIFT_EXPORT_FROM(swift_Concurrency)
 extern void *_Nullable swift_task_asyncMainDrainQueue_hook;
 
+
+/// MARK: - thread local storage
+
+extern _Thread_local void * _Nullable swjs_thread_local_event_loop;
+
 #endif


### PR DESCRIPTION
This change makes `JavaScriptEventLoop` to be allocated per thread in multi-threaded environment. This is necessary to ensure that a job enqueued in one thread is executed in the same thread because JSObject managed by a worker can only be accessed in the same thread.

Currently, `swift_task_enqueueMainExecutor_hook` continues enqueuing jobs to the current thread event loop. It should eventually enqueue to the main thread event loop even if it's enqueued from worker threads.