### PR TITLE
Update macro conditions for runtime usage

### DIFF
--- a/Sources/JavaScriptEventLoop/JavaScriptEventLoop.swift
+++ b/Sources/JavaScriptEventLoop/JavaScriptEventLoop.swift
@@ -61,7 +61,7 @@ public final class JavaScriptEventLoop: SerialExecutor, @unchecked Sendable {
         return _shared
     }
 
-    #if compiler(>=6.0) && _runtime(_multithreaded)
+    #if compiler(>=6.1) && _runtime(_multithreaded)
     // In multi-threaded environment, we have an event loop executor per
     // thread (per Web Worker). A job enqueued in one thread should be
     // executed in the same thread under this global executor.

--- a/Sources/JavaScriptEventLoop/JavaScriptEventLoop.swift
+++ b/Sources/JavaScriptEventLoop/JavaScriptEventLoop.swift
@@ -61,7 +61,7 @@ public final class JavaScriptEventLoop: SerialExecutor, @unchecked Sendable {
         return _shared
     }
 
-    #if compiler(>=6.0) && hasFeature(Extern) && _runtime(_multithreaded)
+    #if compiler(>=6.0) && hasFeature(IsolatedAny2) && _runtime(_multithreaded)
     // In multi-threaded environment, we have an event loop executor per
     // thread (per Web Worker). A job enqueued in one thread should be
     // executed in the same thread under this global executor.

--- a/Sources/JavaScriptEventLoop/JavaScriptEventLoop.swift
+++ b/Sources/JavaScriptEventLoop/JavaScriptEventLoop.swift
@@ -61,7 +61,7 @@ public final class JavaScriptEventLoop: SerialExecutor, @unchecked Sendable {
         return _shared
     }
 
-    #if compiler(>=6.1) && _runtime(_multithreaded)
+    #if compiler(>=6.0) && hasFeature(Extern) && _runtime(_multithreaded)
     // In multi-threaded environment, we have an event loop executor per
     // thread (per Web Worker). A job enqueued in one thread should be
     // executed in the same thread under this global executor.

--- a/Sources/JavaScriptEventLoop/WebWorkerTaskExecutor.swift
+++ b/Sources/JavaScriptEventLoop/WebWorkerTaskExecutor.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.0) && hasFeature(Extern) && _runtime(_multithreaded) // @_expose and @_extern are only available in Swift 6.0+
+#if compiler(>=6.0) && hasFeature(IsolatedAny2) && _runtime(_multithreaded) // @_expose and @_extern are only available in Swift 6.0+
 
 import JavaScriptKit
 import _CJavaScriptKit

--- a/Sources/JavaScriptEventLoop/WebWorkerTaskExecutor.swift
+++ b/Sources/JavaScriptEventLoop/WebWorkerTaskExecutor.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.1) && _runtime(_multithreaded) // @_expose and @_extern are only available in Swift 6.0+
+#if compiler(>=6.0) && hasFeature(Extern) && _runtime(_multithreaded) // @_expose and @_extern are only available in Swift 6.0+
 
 import JavaScriptKit
 import _CJavaScriptKit

--- a/Sources/JavaScriptEventLoop/WebWorkerTaskExecutor.swift
+++ b/Sources/JavaScriptEventLoop/WebWorkerTaskExecutor.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.0) && _runtime(_multithreaded) // @_expose and @_extern are only available in Swift 6.0+
+#if compiler(>=6.1) && _runtime(_multithreaded) // @_expose and @_extern are only available in Swift 6.0+
 
 import JavaScriptKit
 import _CJavaScriptKit

--- a/Tests/JavaScriptEventLoopTests/WebWorkerTaskExecutorTests.swift
+++ b/Tests/JavaScriptEventLoopTests/WebWorkerTaskExecutorTests.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.1) && _runtime(_multithreaded)
+#if compiler(>=6.0) && hasFeature(Extern) && _runtime(_multithreaded)
 import XCTest
 import JavaScriptKit
 import _CJavaScriptKit // For swjs_get_worker_thread_id

--- a/Tests/JavaScriptEventLoopTests/WebWorkerTaskExecutorTests.swift
+++ b/Tests/JavaScriptEventLoopTests/WebWorkerTaskExecutorTests.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.0) && hasFeature(Extern) && _runtime(_multithreaded)
+#if compiler(>=6.0) && hasFeature(IsolatedAny2) && _runtime(_multithreaded)
 import XCTest
 import JavaScriptKit
 import _CJavaScriptKit // For swjs_get_worker_thread_id

--- a/Tests/JavaScriptEventLoopTests/WebWorkerTaskExecutorTests.swift
+++ b/Tests/JavaScriptEventLoopTests/WebWorkerTaskExecutorTests.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.0) && _runtime(_multithreaded)
+#if compiler(>=6.1) && _runtime(_multithreaded)
 import XCTest
 import JavaScriptKit
 import _CJavaScriptKit // For swjs_get_worker_thread_id


### PR DESCRIPTION
`_runtime(_multithreaded)` is available only in the main snapshot toolchain, but unavailable in 6.0. However, we cannot distinguish them because `compiler(>=6.1)` is still false in the main snapshot toolchain. Thus add `hasFeature(IsolatedAny2)` condition, which is only available in main snapshot toolchains.