### PR TITLE
Use `compiler(>=6.1)` to gate for the main branch toolchain

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,10 +76,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-13
-            xcode: Xcode_14.3
           - os: macos-14
             xcode: Xcode_15.2
+          - os: macos-15
+            xcode: Xcode_16
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/Sources/JavaScriptEventLoop/JavaScriptEventLoop.swift
+++ b/Sources/JavaScriptEventLoop/JavaScriptEventLoop.swift
@@ -61,7 +61,7 @@ public final class JavaScriptEventLoop: SerialExecutor, @unchecked Sendable {
         return _shared
     }
 
-    #if compiler(>=6.0) && hasFeature(IsolatedAny2) && _runtime(_multithreaded)
+    #if compiler(>=6.1) && _runtime(_multithreaded)
     // In multi-threaded environment, we have an event loop executor per
     // thread (per Web Worker). A job enqueued in one thread should be
     // executed in the same thread under this global executor.

--- a/Sources/JavaScriptEventLoop/WebWorkerTaskExecutor.swift
+++ b/Sources/JavaScriptEventLoop/WebWorkerTaskExecutor.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.1) && _runtime(_multithreaded) // @_expose and @_extern are only available in Swift 6.0+
+#if compiler(>=6.1) && _runtime(_multithreaded) // @_expose and @_extern are only available in Swift 6.1+
 
 import JavaScriptKit
 import _CJavaScriptKit
@@ -274,6 +274,7 @@ public final class WebWorkerTaskExecutor: TaskExecutor {
         }
 
         func start(timeout: Duration, checkInterval: Duration) async throws {
+            #if canImport(wasi_pthread)
             class Context: @unchecked Sendable {
                 let executor: WebWorkerTaskExecutor.Executor
                 let worker: Worker
@@ -316,6 +317,9 @@ public final class WebWorkerTaskExecutor: TaskExecutor {
                 } while tid == 0
                 swjs_listen_message_from_worker_thread(tid)
             }
+            #else
+            fatalError("Unsupported platform")
+            #endif
         }
 
         func terminate() {
@@ -420,6 +424,7 @@ public final class WebWorkerTaskExecutor: TaskExecutor {
     ///
     /// This function must be called once before using the Web Worker task executor.
     public static func installGlobalExecutor() {
+        #if canImport(wasi_pthread)
         // Ensure this function is called only once.
         guard _mainThread == nil else { return }
 
@@ -448,6 +453,9 @@ public final class WebWorkerTaskExecutor: TaskExecutor {
             }
         }
         swift_task_enqueueGlobal_hook = unsafeBitCast(swift_task_enqueueGlobal_hook_impl, to: UnsafeMutableRawPointer?.self)
+        #else
+        fatalError("Unsupported platform")
+        #endif
     }
 }
 

--- a/Sources/JavaScriptEventLoop/WebWorkerTaskExecutor.swift
+++ b/Sources/JavaScriptEventLoop/WebWorkerTaskExecutor.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.0) && hasFeature(IsolatedAny2) && _runtime(_multithreaded) // @_expose and @_extern are only available in Swift 6.0+
+#if compiler(>=6.1) && _runtime(_multithreaded) // @_expose and @_extern are only available in Swift 6.0+
 
 import JavaScriptKit
 import _CJavaScriptKit

--- a/Tests/JavaScriptEventLoopTests/WebWorkerTaskExecutorTests.swift
+++ b/Tests/JavaScriptEventLoopTests/WebWorkerTaskExecutorTests.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.0) && hasFeature(IsolatedAny2) && _runtime(_multithreaded)
+#if compiler(>=6.1) && _runtime(_multithreaded)
 import XCTest
 import JavaScriptKit
 import _CJavaScriptKit // For swjs_get_worker_thread_id


### PR DESCRIPTION
We used a hack to distinguish the main branch toolchain and 6.0 branch toolchain, but the main branch has been bumped to 6.1, so we can use `compiler(>=6.1)` to gate for the main branch toolchain.