### PR TITLE
improved embedded support for building with SwiftPM

### DIFF
--- a/Examples/Embedded/Package.swift
+++ b/Examples/Embedded/Package.swift
@@ -16,7 +16,8 @@ let package = Package(
                 .product(name: "dlmalloc", package: "swift-dlmalloc")
             ],
             cSettings: [
-                .unsafeFlags(["-fdeclspec"])
+                .unsafeFlags(["-fdeclspec"]),
+                .define("__Embedded"),
             ],
             swiftSettings: [
                 .enableExperimentalFeature("Embedded"),
@@ -29,7 +30,8 @@ let package = Package(
             linkerSettings: [
                 .unsafeFlags([
                     "-Xclang-linker", "-nostdlib",
-                    "-Xlinker", "--no-entry"
+                    "-Xlinker", "--no-entry",
+                    "-Xlinker", "--export-if-defined=__main_argc_argv"
                 ])
             ]
         )

--- a/Examples/Embedded/Package.swift
+++ b/Examples/Embedded/Package.swift
@@ -15,10 +15,7 @@ let package = Package(
                 "JavaScriptKit",
                 .product(name: "dlmalloc", package: "swift-dlmalloc")
             ],
-            cSettings: [
-                .unsafeFlags(["-fdeclspec"]),
-                .define("__Embedded"),
-            ],
+            cSettings: [.unsafeFlags(["-fdeclspec"])],
             swiftSettings: [
                 .enableExperimentalFeature("Embedded"),
                 .enableExperimentalFeature("Extern"),

--- a/Examples/Embedded/build.sh
+++ b/Examples/Embedded/build.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 package_dir="$(cd "$(dirname "$0")" && pwd)"
-JAVASCRIPTKIT_EXPERIMENTAL_EMBEDDED_WASM=true swift build --package-path "$package_dir" -c release --product EmbeddedApp \
-  --triple wasm32-unknown-none-wasm  \
-  -Xswiftc -enable-experimental-feature -Xswiftc Embedded \
-  -Xswiftc -enable-experimental-feature -Xswiftc Extern \
-  -Xcc -D__Embedded -Xcc -fdeclspec \
-  -Xlinker --export-if-defined=__main_argc_argv \
-  -Xlinker --export-if-defined=swjs_call_host_function \
-  -Xswiftc -Xclang-linker -Xswiftc -mexec-model=reactor
+JAVASCRIPTKIT_EXPERIMENTAL_EMBEDDED_WASM=true \
+  swift build --package-path "$package_dir" --product EmbeddedApp \
+  -c release --triple wasm32-unknown-none-wasm

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.8
 
 import PackageDescription
 import Foundation
@@ -19,11 +19,21 @@ let package = Package(
             name: "JavaScriptKit",
             dependencies: ["_CJavaScriptKit"], 
             resources: shouldBuildForEmbedded ? [] : [.copy("Runtime")],
+            cSettings: shouldBuildForEmbedded ? [
+                    .unsafeFlags(["-fdeclspec"]),
+                    .define("__Embedded"),
+                ] : nil,
             swiftSettings: shouldBuildForEmbedded 
-                ? [.unsafeFlags(["-Xfrontend", "-emit-empty-object-file"])] 
-                : []
+                ? [
+                    .enableExperimentalFeature("Embedded"),
+                    .enableExperimentalFeature("Extern"),
+                    .unsafeFlags(["-Xfrontend", "-emit-empty-object-file"])
+                ] : nil,
         ),
-        .target(name: "_CJavaScriptKit"),
+        .target(
+            name: "_CJavaScriptKit",
+            cSettings: shouldBuildForEmbedded ? [.define("__Embedded")] : nil
+        ),
         .target(
             name: "JavaScriptBigIntSupport",
             dependencies: ["_CJavaScriptBigIntSupport", "JavaScriptKit"]

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,9 @@
 // swift-tools-version:5.8
 
 import PackageDescription
-import Foundation
 
 // NOTE: needed for embedded customizations, ideally this will not be necessary at all in the future, or can be replaced with traits
-let shouldBuildForEmbedded = ProcessInfo.processInfo.environment["JAVASCRIPTKIT_EXPERIMENTAL_EMBEDDED_WASM"].flatMap(Bool.init) ?? false
+let shouldBuildForEmbedded = Context.environment["JAVASCRIPTKIT_EXPERIMENTAL_EMBEDDED_WASM"].flatMap(Bool.init) ?? false
 
 let package = Package(
     name: "JavaScriptKit",

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
                     .enableExperimentalFeature("Embedded"),
                     .enableExperimentalFeature("Extern"),
                     .unsafeFlags(["-Xfrontend", "-emit-empty-object-file"])
-                ] : nil,
+                ] : nil
         ),
         .target(name: "_CJavaScriptKit"),
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,7 @@ let package = Package(
             dependencies: ["_CJavaScriptKit"], 
             resources: shouldBuildForEmbedded ? [] : [.copy("Runtime")],
             cSettings: shouldBuildForEmbedded ? [
-                    .unsafeFlags(["-fdeclspec"]),
-                    .define("__Embedded"),
+                    .unsafeFlags(["-fdeclspec"])
                 ] : nil,
             swiftSettings: shouldBuildForEmbedded 
                 ? [
@@ -29,10 +28,7 @@ let package = Package(
                     .unsafeFlags(["-Xfrontend", "-emit-empty-object-file"])
                 ] : nil,
         ),
-        .target(
-            name: "_CJavaScriptKit",
-            cSettings: shouldBuildForEmbedded ? [.define("__Embedded")] : nil
-        ),
+        .target(name: "_CJavaScriptKit"),
         .target(
             name: "JavaScriptBigIntSupport",
             dependencies: ["_CJavaScriptBigIntSupport", "JavaScriptKit"]

--- a/Sources/_CJavaScriptKit/_CJavaScriptKit.c
+++ b/Sources/_CJavaScriptKit/_CJavaScriptKit.c
@@ -1,6 +1,6 @@
 #include "_CJavaScriptKit.h"
 #if __wasm32__
-#if __Embedded
+#ifndef __wasi__
 #if __has_include("malloc.h")
 #include <malloc.h>
 #endif
@@ -31,8 +31,10 @@ void swjs_cleanup_host_function_call(void *argv_buffer) {
     free(argv_buffer);
 }
 
-#ifndef __Embedded
-// cdecls don't work in Embedded, also @_expose(wasm) can be used with Swift >=6.0
+// NOTE: This __wasi__ check is a hack for Embedded compatibility (assuming that if __wasi__ is defined, we are not building for Embedded)
+// cdecls don't work in Embedded, but @_expose(wasm) can be used with Swift >=6.0
+// the previously used `#if __Embedded` did not play well with SwiftPM (defines needed to be on every target up the chain)
+#ifdef __wasi__
 bool _call_host_function_impl(const JavaScriptHostFuncRef host_func_ref,
                               const RawJSValue *argv, const int argc,
                               const JavaScriptObjectRef callback_func);

--- a/Sources/_CJavaScriptKit/include/_CJavaScriptKit.h
+++ b/Sources/_CJavaScriptKit/include/_CJavaScriptKit.h
@@ -1,7 +1,7 @@
 #ifndef _CJavaScriptKit_h
 #define _CJavaScriptKit_h
 
-#if __Embedded
+#ifndef __wasi__
 #include <stddef.h>
 #else
 #include <stdlib.h>

--- a/Sources/_CJavaScriptKit/include/_CJavaScriptKit.h
+++ b/Sources/_CJavaScriptKit/include/_CJavaScriptKit.h
@@ -1,10 +1,10 @@
 #ifndef _CJavaScriptKit_h
 #define _CJavaScriptKit_h
 
-#ifndef __wasi__
-#include <stddef.h>
-#else
+#if __has_include("stdlib.h")
 #include <stdlib.h>
+#else
+#include <stddef.h>
 #endif
 #include <stdbool.h>
 #include <stdint.h>


### PR DESCRIPTION
Having to provide a lot of external flags to `swift build` is not ideal and basically breaks down when adding swift macro targets.

This PR pushes the currently required flags into the `Package.swift` file to allow building without any global flags provided to the build command.

NOTE: The `__Embedded` define for the C target configuration did not play well with SwiftPM, so I based the logic on `__wasi__` (thanks @MaxDesiatov for the idea). However, it is not a perfect match and I hope a better solution will present itself in the future.