### PR TITLE
Assert that `JSObject` is being accessed only from the owner thread

### DIFF
--- a/IntegrationTests/lib.js
+++ b/IntegrationTests/lib.js
@@ -128,6 +128,7 @@ class ThreadRegistry {
 
         worker.on("error", (error) => {
             console.error(`Worker thread ${tid} error:`, error);
+            throw error;
         });
         this.workers.set(tid, worker);
         worker.postMessage({ selfFilePath, module, programName, memory, tid, startArg });

--- a/Package.swift
+++ b/Package.swift
@@ -58,6 +58,11 @@ let package = Package(
             ]
         ),
         .target(name: "_CJavaScriptEventLoopTestSupport"),
+
+        .testTarget(
+            name: "JavaScriptKitTests",
+            dependencies: ["JavaScriptKit"]
+        ),
         .testTarget(
           name: "JavaScriptEventLoopTestSupportTests",
           dependencies: [

--- a/Sources/JavaScriptBigIntSupport/Int64+I64.swift
+++ b/Sources/JavaScriptBigIntSupport/Int64+I64.swift
@@ -1,13 +1,13 @@
 import JavaScriptKit
 
 extension UInt64: JavaScriptKit.ConvertibleToJSValue, JavaScriptKit.TypedArrayElement {
-    public static var typedArrayClass = JSObject.global.BigUint64Array.function!
+    public static var typedArrayClass: JSFunction { JSObject.global.BigUint64Array.function! }
 
     public var jsValue: JSValue { .bigInt(JSBigInt(unsigned: self)) }
 }
 
 extension Int64: JavaScriptKit.ConvertibleToJSValue, JavaScriptKit.TypedArrayElement {
-    public static var typedArrayClass = JSObject.global.BigInt64Array.function!
+    public static var typedArrayClass: JSFunction { JSObject.global.BigInt64Array.function! }
 
     public var jsValue: JSValue { .bigInt(JSBigInt(self)) }
 }

--- a/Sources/JavaScriptKit/BasicObjects/JSArray.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSArray.swift
@@ -2,7 +2,9 @@
 /// class](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)
 /// that exposes its properties in a type-safe and Swifty way.
 public class JSArray: JSBridgedClass {
-    public static let constructor = JSObject.global.Array.function
+    public static var constructor: JSFunction? { _constructor }
+    @LazyThreadLocal(initialize: { JSObject.global.Array.function })
+    private static var _constructor: JSFunction?
 
     static func isArray(_ object: JSObject) -> Bool {
         constructor!.isArray!(object).boolean!

--- a/Sources/JavaScriptKit/BasicObjects/JSDate.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSDate.swift
@@ -8,7 +8,9 @@
  */
 public final class JSDate: JSBridgedClass {
     /// The constructor function used to create new `Date` objects.
-    public static let constructor = JSObject.global.Date.function
+    public static var constructor: JSFunction? { _constructor }
+    @LazyThreadLocal(initialize: { JSObject.global.Date.function })
+    private static var _constructor: JSFunction?
 
     /// The underlying JavaScript `Date` object.
     public let jsObject: JSObject

--- a/Sources/JavaScriptKit/BasicObjects/JSError.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSError.swift
@@ -4,7 +4,9 @@
  */
 public final class JSError: Error, JSBridgedClass {
     /// The constructor function used to create new JavaScript `Error` objects.
-    public static let constructor = JSObject.global.Error.function
+    public static var constructor: JSFunction? { _constructor }
+    @LazyThreadLocal(initialize: { JSObject.global.Error.function })
+    private static var _constructor: JSFunction?
 
     /// The underlying JavaScript `Error` object.
     public let jsObject: JSObject

--- a/Sources/JavaScriptKit/FundamentalObjects/JSBigInt.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSBigInt.swift
@@ -1,6 +1,6 @@
 import _CJavaScriptKit
 
-private let constructor = JSObject.global.BigInt.function!
+private var constructor: JSFunction { JSObject.global.BigInt.function! }
 
 /// A wrapper around [the JavaScript `BigInt`
 /// class](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)
@@ -30,9 +30,9 @@ public final class JSBigInt: JSObject {
 
     public func clamped(bitSize: Int, signed: Bool) -> JSBigInt {
         if signed {
-            return constructor.asIntN!(bitSize, self).bigInt!
+            return constructor.asIntN(bitSize, self).bigInt!
         } else {
-            return constructor.asUintN!(bitSize, self).bigInt!
+            return constructor.asUintN(bitSize, self).bigInt!
         }
     }
 }

--- a/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
@@ -22,6 +22,10 @@ import _CJavaScriptKit
 /// reference counting system.
 @dynamicMemberLookup
 public class JSObject: Equatable {
+    internal static var constructor: JSFunction { _constructor }
+    @LazyThreadLocal(initialize: { JSObject.global.Object.function! })
+    internal static var _constructor: JSFunction
+
     @_spi(JSObject_id)
     public var id: JavaScriptObjectRef
 

--- a/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
@@ -1,7 +1,9 @@
 import _CJavaScriptKit
 
-#if canImport(wasi_pthread)
-    import wasi_pthread
+#if arch(wasm32)
+    #if canImport(wasi_pthread)
+        import wasi_pthread
+    #endif
 #else
     import Foundation // for pthread_t on non-wasi platforms
 #endif

--- a/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
@@ -206,19 +206,10 @@ public class JSObject: Equatable {
 
     // `JSObject` storage itself is immutable, and use of `JSObject.global` from other
     // threads maintains the same semantics as `globalThis` in JavaScript.
-    #if compiler(>=6.1) && _runtime(_multithreaded)
-        @LazyThreadLocal(initialize: {
-            return JSObject(id: _JS_Predef_Value_Global)
-        })
-        private static var _global: JSObject
-    #else
-        #if compiler(>=5.10)
-        nonisolated(unsafe)
-        static let _global = JSObject(id: _JS_Predef_Value_Global)
-        #else
-        static let _global = JSObject(id: _JS_Predef_Value_Global)
-        #endif
-    #endif
+    @LazyThreadLocal(initialize: {
+        return JSObject(id: _JS_Predef_Value_Global)
+    })
+    private static var _global: JSObject
 
     deinit {
         assertOnOwnerThread(hint: "deinitializing")

--- a/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
@@ -29,7 +29,7 @@ public class JSObject: Equatable {
     @_spi(JSObject_id)
     public var id: JavaScriptObjectRef
 
-#if _runtime(_multithreaded)
+#if compiler(>=6.1) && _runtime(_multithreaded)
     private let ownerThread: pthread_t
 #endif
 
@@ -47,14 +47,14 @@ public class JSObject: Equatable {
     /// is a programmer error and will result in a runtime assertion failure because JavaScript
     /// object spaces are not shared across threads backed by Web Workers.
     private func assertOnOwnerThread(hint: @autoclosure () -> String) {
-        #if _runtime(_multithreaded)
+        #if compiler(>=6.1) && _runtime(_multithreaded)
         precondition(pthread_equal(ownerThread, pthread_self()) != 0, "JSObject is being accessed from a thread other than the owner thread: \(hint())")
         #endif
     }
 
     /// Asserts that the two objects being compared are owned by the same thread.
     private static func assertSameOwnerThread(lhs: JSObject, rhs: JSObject, hint: @autoclosure () -> String) {
-        #if _runtime(_multithreaded)
+        #if compiler(>=6.1) && _runtime(_multithreaded)
         precondition(pthread_equal(lhs.ownerThread, rhs.ownerThread) != 0, "JSObject is being accessed from a thread other than the owner thread: \(hint())")
         #endif
     }
@@ -206,7 +206,7 @@ public class JSObject: Equatable {
 
     // `JSObject` storage itself is immutable, and use of `JSObject.global` from other
     // threads maintains the same semantics as `globalThis` in JavaScript.
-    #if _runtime(_multithreaded)
+    #if compiler(>=6.1) && _runtime(_multithreaded)
         @LazyThreadLocal(initialize: {
             return JSObject(id: _JS_Predef_Value_Global)
         })

--- a/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
@@ -36,7 +36,9 @@ public class JSObject: Equatable {
     @_spi(JSObject_id)
     public init(id: JavaScriptObjectRef) {
         self.id = id
+#if compiler(>=6.1) && _runtime(_multithreaded)
         self.ownerThread = pthread_self()
+#endif
     }
 
     /// Asserts that the object is being accessed from the owner thread.

--- a/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
@@ -206,8 +206,6 @@ public class JSObject: Equatable {
     /// This allows access to the global properties and global names by accessing the `JSObject` returned.
     public static var global: JSObject { return _global }
 
-    // `JSObject` storage itself is immutable, and use of `JSObject.global` from other
-    // threads maintains the same semantics as `globalThis` in JavaScript.
     @LazyThreadLocal(initialize: {
         return JSObject(id: _JS_Predef_Value_Global)
     })

--- a/Sources/JavaScriptKit/FundamentalObjects/JSSymbol.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSSymbol.swift
@@ -47,17 +47,17 @@ public class JSSymbol: JSObject {
 }
 
 extension JSSymbol {
-    public static let asyncIterator: JSSymbol! = Symbol.asyncIterator.symbol
-    public static let hasInstance: JSSymbol! = Symbol.hasInstance.symbol
-    public static let isConcatSpreadable: JSSymbol! = Symbol.isConcatSpreadable.symbol
-    public static let iterator: JSSymbol! = Symbol.iterator.symbol
-    public static let match: JSSymbol! = Symbol.match.symbol
-    public static let matchAll: JSSymbol! = Symbol.matchAll.symbol
-    public static let replace: JSSymbol! = Symbol.replace.symbol
-    public static let search: JSSymbol! = Symbol.search.symbol
-    public static let species: JSSymbol! = Symbol.species.symbol
-    public static let split: JSSymbol! = Symbol.split.symbol
-    public static let toPrimitive: JSSymbol! = Symbol.toPrimitive.symbol
-    public static let toStringTag: JSSymbol! = Symbol.toStringTag.symbol
-    public static let unscopables: JSSymbol! = Symbol.unscopables.symbol
+    public static var asyncIterator: JSSymbol! { Symbol.asyncIterator.symbol }
+    public static var hasInstance: JSSymbol! { Symbol.hasInstance.symbol }
+    public static var isConcatSpreadable: JSSymbol! { Symbol.isConcatSpreadable.symbol }
+    public static var iterator: JSSymbol! { Symbol.iterator.symbol }
+    public static var match: JSSymbol! { Symbol.match.symbol }
+    public static var matchAll: JSSymbol! { Symbol.matchAll.symbol }
+    public static var replace: JSSymbol! { Symbol.replace.symbol }
+    public static var search: JSSymbol! { Symbol.search.symbol }
+    public static var species: JSSymbol! { Symbol.species.symbol }
+    public static var split: JSSymbol! { Symbol.split.symbol }
+    public static var toPrimitive: JSSymbol! { Symbol.toPrimitive.symbol }
+    public static var toStringTag: JSSymbol! { Symbol.toStringTag.symbol }
+    public static var unscopables: JSSymbol! { Symbol.unscopables.symbol }
 }

--- a/Sources/JavaScriptKit/JSValueDecoder.swift
+++ b/Sources/JavaScriptKit/JSValueDecoder.swift
@@ -35,9 +35,8 @@ private struct _Decoder: Decoder {
 }
 
 private enum Object {
-    static let ref = JSObject.global.Object.function!
     static func keys(_ object: JSObject) -> [String] {
-        let keys = ref.keys!(object).array!
+        let keys = JSObject.constructor.keys!(object).array!
         return keys.map { $0.string! }
     }
 }

--- a/Sources/JavaScriptKit/ThreadLocal.swift
+++ b/Sources/JavaScriptKit/ThreadLocal.swift
@@ -1,4 +1,4 @@
-#if _runtime(_multithreaded)
+#if compiler(>=6.1) && _runtime(_multithreaded)
 #if canImport(wasi_pthread)
 import wasi_pthread
 #elseif canImport(Darwin)

--- a/Sources/JavaScriptKit/ThreadLocal.swift
+++ b/Sources/JavaScriptKit/ThreadLocal.swift
@@ -78,11 +78,14 @@ final class ThreadLocal<Value>: Sendable {
     }
 #else
     // Fallback implementation for platforms that don't support pthread
-    #if compiler(>=5.10)
-    nonisolated(unsafe) var wrappedValue: Value?
-    #else
-    var wrappedValue: Value?
-    #endif
+    private class SendableBox: @unchecked Sendable {
+        var value: Value? = nil
+    }
+    private let _storage = SendableBox()
+    var wrappedValue: Value? {
+        get { _storage.value }
+        set { _storage.value = newValue }
+    }
 
     init() where Value: AnyObject {
         wrappedValue = nil

--- a/Sources/JavaScriptKit/ThreadLocal.swift
+++ b/Sources/JavaScriptKit/ThreadLocal.swift
@@ -1,5 +1,7 @@
+#if os(WASI)
 #if canImport(wasi_pthread)
 import wasi_pthread
+#endif
 #elseif canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
@@ -77,7 +79,7 @@ final class ThreadLocal<Value>: Sendable {
 #else
     // Fallback implementation for platforms that don't support pthread
 
-    var wrappedValue: Value?
+    nonisolated(unsafe) var wrappedValue: Value?
 
     init() where Value: AnyObject {
         wrappedValue = nil

--- a/Sources/JavaScriptKit/ThreadLocal.swift
+++ b/Sources/JavaScriptKit/ThreadLocal.swift
@@ -1,0 +1,103 @@
+#if _runtime(_multithreaded)
+#if canImport(wasi_pthread)
+import wasi_pthread
+#elseif canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#else
+#error("Unsupported platform")
+#endif
+
+@propertyWrapper
+final class ThreadLocal<Value>: Sendable {
+    var wrappedValue: Value? {
+        get {
+            guard let pointer = pthread_getspecific(key) else {
+                return nil
+            }
+            return fromPointer(pointer)
+        }
+        set {
+            if let oldPointer = pthread_getspecific(key) {
+                release(oldPointer)
+            }
+            if let newValue = newValue {
+                let pointer = toPointer(newValue)
+                pthread_setspecific(key, pointer)
+            }
+        }
+    }
+
+    private let key: pthread_key_t
+    private let toPointer: @Sendable (Value) -> UnsafeMutableRawPointer
+    private let fromPointer: @Sendable (UnsafeMutableRawPointer) -> Value
+    private let release: @Sendable (UnsafeMutableRawPointer) -> Void
+
+    init() where Value: AnyObject {
+        var key = pthread_key_t()
+        pthread_key_create(&key, nil)
+        self.key = key
+        self.toPointer = { Unmanaged.passRetained($0).toOpaque() }
+        self.fromPointer = { Unmanaged<Value>.fromOpaque($0).takeUnretainedValue() }
+        self.release = { Unmanaged<Value>.fromOpaque($0).release() }
+    }
+
+    class Box {
+        let value: Value
+        init(_ value: Value) {
+            self.value = value
+        }
+    }
+
+    init(boxing _: Void) {
+        var key = pthread_key_t()
+        pthread_key_create(&key, nil)
+        self.key = key
+        self.toPointer = {
+            let box = Box($0)
+            let pointer = Unmanaged.passRetained(box).toOpaque()
+            return pointer
+        }
+        self.fromPointer = {
+            let box = Unmanaged<Box>.fromOpaque($0).takeUnretainedValue()
+            return box.value
+        }
+        self.release = { Unmanaged<Box>.fromOpaque($0).release() }
+    }
+
+    deinit {
+        if let oldPointer = pthread_getspecific(key) {
+            release(oldPointer)
+        }
+        pthread_key_delete(key)
+    }
+}
+
+@propertyWrapper
+final class LazyThreadLocal<Value>: Sendable {
+    private let storage: ThreadLocal<Value>
+
+    var wrappedValue: Value {
+        if let value = storage.wrappedValue {
+            return value
+        }
+        let value = initialValue()
+        storage.wrappedValue = value
+        return value
+    }
+
+    private let initialValue: @Sendable () -> Value
+
+    init(initialize: @Sendable @escaping () -> Value) where Value: AnyObject {
+        self.storage = ThreadLocal()
+        self.initialValue = initialize
+    }
+
+    init(initialize: @Sendable @escaping () -> Value) {
+        self.storage = ThreadLocal(boxing: ())
+        self.initialValue = initialize
+    }
+}
+
+#endif

--- a/Sources/JavaScriptKit/ThreadLocal.swift
+++ b/Sources/JavaScriptKit/ThreadLocal.swift
@@ -1,4 +1,4 @@
-#if os(WASI)
+#if arch(wasm32)
 #if canImport(wasi_pthread)
 import wasi_pthread
 #endif

--- a/Sources/JavaScriptKit/ThreadLocal.swift
+++ b/Sources/JavaScriptKit/ThreadLocal.swift
@@ -78,8 +78,11 @@ final class ThreadLocal<Value>: Sendable {
     }
 #else
     // Fallback implementation for platforms that don't support pthread
-
+    #if compiler(>=5.10)
     nonisolated(unsafe) var wrappedValue: Value?
+    #else
+    var wrappedValue: Value?
+    #endif
 
     init() where Value: AnyObject {
         wrappedValue = nil

--- a/Tests/JavaScriptEventLoopTests/WebWorkerTaskExecutorTests.swift
+++ b/Tests/JavaScriptEventLoopTests/WebWorkerTaskExecutorTests.swift
@@ -150,5 +150,19 @@ final class WebWorkerTaskExecutorTests: XCTestCase {
         }
         executor.terminate()
     }
+
+/*
+    func testDeinitJSObjectOnDifferentThread() async throws {
+        let executor = try await WebWorkerTaskExecutor(numberOfThreads: 1)
+
+        var object: JSObject? = JSObject.global.Object.function!.new()
+        let task = Task(executorPreference: executor) {
+            object = nil
+            _ = object
+        }
+        await task.value
+        executor.terminate()
+    }
+*/
 }
 #endif

--- a/Tests/JavaScriptKitTests/ThreadLocalTests.swift
+++ b/Tests/JavaScriptKitTests/ThreadLocalTests.swift
@@ -3,11 +3,16 @@ import XCTest
 
 final class ThreadLocalTests: XCTestCase {
     class MyHeapObject {}
+    struct MyStruct {
+        var object: MyHeapObject
+    }
 
     func testLeak() throws {
         struct Check {
             @ThreadLocal
             var value: MyHeapObject?
+            @ThreadLocal(boxing: ())
+            var value2: MyStruct?
         }
         weak var weakObject: MyHeapObject?
         do {
@@ -19,6 +24,17 @@ final class ThreadLocalTests: XCTestCase {
             XCTAssertTrue(check.value === object)
         }
         XCTAssertNil(weakObject)
+
+        weak var weakObject2: MyHeapObject?
+        do {
+            let object = MyHeapObject()
+            weakObject2 = object
+            let check = Check()
+            check.value2 = MyStruct(object: object)
+            XCTAssertNotNil(check.value2)
+            XCTAssertTrue(check.value2!.object === object)
+        }
+        XCTAssertNil(weakObject2)
     }
 
     func testLazyThreadLocal() throws {

--- a/Tests/JavaScriptKitTests/ThreadLocalTests.swift
+++ b/Tests/JavaScriptKitTests/ThreadLocalTests.swift
@@ -10,18 +10,18 @@ final class ThreadLocalTests: XCTestCase {
     func testLeak() throws {
         struct Check {
             @ThreadLocal
-            var value: MyHeapObject?
+            static var value: MyHeapObject?
             @ThreadLocal(boxing: ())
-            var value2: MyStruct?
+            static var value2: MyStruct?
         }
         weak var weakObject: MyHeapObject?
         do {
             let object = MyHeapObject()
             weakObject = object
-            let check = Check()
-            check.value = object
-            XCTAssertNotNil(check.value)
-            XCTAssertTrue(check.value === object)
+            Check.value = object
+            XCTAssertNotNil(Check.value)
+            XCTAssertTrue(Check.value === object)
+            Check.value = nil
         }
         XCTAssertNil(weakObject)
 
@@ -29,10 +29,10 @@ final class ThreadLocalTests: XCTestCase {
         do {
             let object = MyHeapObject()
             weakObject2 = object
-            let check = Check()
-            check.value2 = MyStruct(object: object)
-            XCTAssertNotNil(check.value2)
-            XCTAssertTrue(check.value2!.object === object)
+            Check.value2 = MyStruct(object: object)
+            XCTAssertNotNil(Check.value2)
+            XCTAssertTrue(Check.value2!.object === object)
+            Check.value2 = nil
         }
         XCTAssertNil(weakObject2)
     }
@@ -40,11 +40,10 @@ final class ThreadLocalTests: XCTestCase {
     func testLazyThreadLocal() throws {
         struct Check {
             @LazyThreadLocal(initialize: { MyHeapObject() })
-            var value: MyHeapObject
+            static var value: MyHeapObject
         }
-        let check = Check()
-        let object1 = check.value
-        let object2 = check.value
+        let object1 = Check.value
+        let object2 = Check.value
         XCTAssertTrue(object1 === object2)
     }
 }

--- a/Tests/JavaScriptKitTests/ThreadLocalTests.swift
+++ b/Tests/JavaScriptKitTests/ThreadLocalTests.swift
@@ -9,19 +9,17 @@ final class ThreadLocalTests: XCTestCase {
 
     func testLeak() throws {
         struct Check {
-            @ThreadLocal
-            static var value: MyHeapObject?
-            @ThreadLocal(boxing: ())
-            static var value2: MyStruct?
+            static let value = ThreadLocal<MyHeapObject>()
+            static let value2 = ThreadLocal<MyStruct>(boxing: ())
         }
         weak var weakObject: MyHeapObject?
         do {
             let object = MyHeapObject()
             weakObject = object
-            Check.value = object
-            XCTAssertNotNil(Check.value)
-            XCTAssertTrue(Check.value === object)
-            Check.value = nil
+            Check.value.wrappedValue = object
+            XCTAssertNotNil(Check.value.wrappedValue)
+            XCTAssertTrue(Check.value.wrappedValue === object)
+            Check.value.wrappedValue = nil
         }
         XCTAssertNil(weakObject)
 
@@ -29,21 +27,20 @@ final class ThreadLocalTests: XCTestCase {
         do {
             let object = MyHeapObject()
             weakObject2 = object
-            Check.value2 = MyStruct(object: object)
-            XCTAssertNotNil(Check.value2)
-            XCTAssertTrue(Check.value2!.object === object)
-            Check.value2 = nil
+            Check.value2.wrappedValue = MyStruct(object: object)
+            XCTAssertNotNil(Check.value2.wrappedValue)
+            XCTAssertTrue(Check.value2.wrappedValue!.object === object)
+            Check.value2.wrappedValue = nil
         }
         XCTAssertNil(weakObject2)
     }
 
     func testLazyThreadLocal() throws {
         struct Check {
-            @LazyThreadLocal(initialize: { MyHeapObject() })
-            static var value: MyHeapObject
+            static let value = LazyThreadLocal(initialize: { MyHeapObject() })
         }
-        let object1 = Check.value
-        let object2 = Check.value
+        let object1 = Check.value.wrappedValue
+        let object2 = Check.value.wrappedValue
         XCTAssertTrue(object1 === object2)
     }
 }

--- a/Tests/JavaScriptKitTests/ThreadLocalTests.swift
+++ b/Tests/JavaScriptKitTests/ThreadLocalTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import JavaScriptKit
+
+final class ThreadLocalTests: XCTestCase {
+    class MyHeapObject {}
+
+    func testLeak() throws {
+        struct Check {
+            @ThreadLocal
+            var value: MyHeapObject?
+        }
+        weak var weakObject: MyHeapObject?
+        do {
+            let object = MyHeapObject()
+            weakObject = object
+            let check = Check()
+            check.value = object
+            XCTAssertNotNil(check.value)
+            XCTAssertTrue(check.value === object)
+        }
+        XCTAssertNil(weakObject)
+    }
+
+    func testLazyThreadLocal() throws {
+        struct Check {
+            @LazyThreadLocal(initialize: { MyHeapObject() })
+            var value: MyHeapObject
+        }
+        let check = Check()
+        let object1 = check.value
+        let object2 = check.value
+        XCTAssertTrue(object1 === object2)
+    }
+}


### PR DESCRIPTION
This is not the ideal solution but it's much better than silently corrupting the heap space. Partially resolve https://github.com/swiftwasm/JavaScriptKit/issues/271