### PR TITLE
Stop use of global variable as a object cache

### DIFF
--- a/Sources/JavaScriptKit/BasicObjects/JSArray.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSArray.swift
@@ -93,9 +93,9 @@ extension JSArray: RandomAccessCollection {
     }
 }
 
-private let alwaysTrue = JSClosure { _ in .boolean(true) }
+private let alwaysTrue = LazyThreadLocal(initialize: { JSClosure { _ in .boolean(true) } })
 private func getObjectValuesLength(_ object: JSObject) -> Int {
-    let values = object.filter!(alwaysTrue).object!
+    let values = object.filter!(alwaysTrue.wrappedValue).object!
     return Int(values.length.number!)
 }
 

--- a/Sources/JavaScriptKit/ConvertibleToJSValue.swift
+++ b/Sources/JavaScriptKit/ConvertibleToJSValue.swift
@@ -85,8 +85,10 @@ extension JSObject: JSValueCompatible {
     // from `JSFunction`
 }
 
-private let objectConstructor = JSObject.global.Object.function!
-private let arrayConstructor = JSObject.global.Array.function!
+private let _objectConstructor = LazyThreadLocal(initialize: { JSObject.global.Object.function! })
+private var objectConstructor: JSFunction { _objectConstructor.wrappedValue }
+private let _arrayConstructor = LazyThreadLocal(initialize: { JSObject.global.Array.function! })
+private var arrayConstructor: JSFunction { _arrayConstructor.wrappedValue }
 
 #if !hasFeature(Embedded)
 extension Dictionary where Value == ConvertibleToJSValue, Key == String {

--- a/Sources/JavaScriptKit/FundamentalObjects/JSSymbol.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSSymbol.swift
@@ -1,6 +1,7 @@
 import _CJavaScriptKit
 
-private let Symbol = JSObject.global.Symbol.function!
+private let _Symbol = LazyThreadLocal(initialize: { JSObject.global.Symbol.function! })
+private var Symbol: JSFunction { _Symbol.wrappedValue }
 
 /// A wrapper around [the JavaScript `Symbol`
 /// class](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol)


### PR DESCRIPTION
Fix crash on workers due to use of JSObject referencing main thread objects