### PR TITLE
Fix empty TypedArray creation

### DIFF
--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -536,6 +536,15 @@ export class SwiftRuntime {
             ) => {
                 const ArrayType: TypedArray =
                     this.memory.getObject(constructor_ref);
+                if (length == 0) {
+                    // The elementsPtr can be unaligned in Swift's Array
+                    // implementation when the array is empty. However,
+                    // TypedArray requires the pointer to be aligned.
+                    // So, we need to create a new empty array without
+                    // using the elementsPtr.
+                    // See https://github.com/swiftwasm/swift/issues/5599
+                    return this.memory.retain(new ArrayType());
+                }
                 const array = new ArrayType(
                     this.memory.rawMemory.buffer,
                     elementsPtr,

--- a/Sources/JavaScriptKit/Runtime/index.js
+++ b/Sources/JavaScriptKit/Runtime/index.js
@@ -451,6 +451,15 @@
                 },
                 swjs_create_typed_array: (constructor_ref, elementsPtr, length) => {
                     const ArrayType = this.memory.getObject(constructor_ref);
+                    if (length == 0) {
+                        // The elementsPtr can be unaligned in Swift's Array
+                        // implementation when the array is empty. However,
+                        // TypedArray requires the pointer to be aligned.
+                        // So, we need to create a new empty array without
+                        // using the elementsPtr.
+                        // See https://github.com/swiftwasm/swift/issues/5599
+                        return this.memory.retain(new ArrayType());
+                    }
                     const array = new ArrayType(this.memory.rawMemory.buffer, elementsPtr, length);
                     // Call `.slice()` to copy the memory
                     return this.memory.retain(array.slice());

--- a/Sources/JavaScriptKit/Runtime/index.mjs
+++ b/Sources/JavaScriptKit/Runtime/index.mjs
@@ -445,6 +445,15 @@ class SwiftRuntime {
             },
             swjs_create_typed_array: (constructor_ref, elementsPtr, length) => {
                 const ArrayType = this.memory.getObject(constructor_ref);
+                if (length == 0) {
+                    // The elementsPtr can be unaligned in Swift's Array
+                    // implementation when the array is empty. However,
+                    // TypedArray requires the pointer to be aligned.
+                    // So, we need to create a new empty array without
+                    // using the elementsPtr.
+                    // See https://github.com/swiftwasm/swift/issues/5599
+                    return this.memory.retain(new ArrayType());
+                }
                 const array = new ArrayType(this.memory.rawMemory.buffer, elementsPtr, length);
                 // Call `.slice()` to copy the memory
                 return this.memory.retain(array.slice());

--- a/Tests/JavaScriptKitTests/JSTypedArrayTests.swift
+++ b/Tests/JavaScriptKitTests/JSTypedArrayTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+import JavaScriptKit
+
+final class JSTypedArrayTests: XCTestCase {
+    func testEmptyArray() {
+        _ = JSTypedArray<Int>([])
+        _ = JSTypedArray<UInt>([])
+        _ = JSTypedArray<Int8>([Int8]())
+        _ = JSTypedArray<UInt8>([UInt8]())
+        _ = JSUInt8ClampedArray([UInt8]())
+        _ = JSTypedArray<Int16>([Int16]())
+        _ = JSTypedArray<UInt16>([UInt16]())
+        _ = JSTypedArray<Int32>([Int32]())
+        _ = JSTypedArray<UInt32>([UInt32]())
+        _ = JSTypedArray<Float32>([Float32]())
+        _ = JSTypedArray<Float64>([Float64]())
+    }
+}


### PR DESCRIPTION
Close https://github.com/swiftwasm/swift/issues/5599

Empty array instances share the same storage for all element types, so their `baseAddress` can be unaligned. (It seems the empty array storage had been placed at 8-aligned position fortunately but it's no longer the case since Swift 6.0, I guess)

https://github.com/swiftlang/swift/blob/2914d0e46eda33cadfd81c3381e8737855ce397c/stdlib/public/stubs/GlobalObjects.cpp#L42