### PR TITLE
Support JS function calls with up to 7 arguments in Embedded Swift

### DIFF
--- a/Sources/JavaScriptKit/FundamentalObjects/JSFunction.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSFunction.swift
@@ -164,7 +164,14 @@ public class JSFunction: JSObject {
 }
 
 #if hasFeature(Embedded)
-// NOTE: once embedded supports variadic generics, we can remove these overloads
+// Overloads of `callAsFunction(ConvertibleToJSValue...) -> JSValue`
+// for 0 through 7 arguments for Embedded Swift.
+//
+// These are required because the `ConvertibleToJSValue...` version is not
+// available in Embedded Swift due to lack of support for existentials.
+//
+// Once Embedded Swift supports parameter packs/variadic generics, we can
+// replace all variants with a single method each that takes a generic pack.
 public extension JSFunction {
 
     @discardableResult
@@ -178,13 +185,72 @@ public extension JSFunction {
     }
 
     @discardableResult
-    func callAsFunction(this: JSObject, _ arg0: some ConvertibleToJSValue, _ arg1: some ConvertibleToJSValue) -> JSValue {
+    func callAsFunction(
+        this: JSObject,
+        _ arg0: some ConvertibleToJSValue,
+        _ arg1: some ConvertibleToJSValue
+    ) -> JSValue {
         invokeNonThrowingJSFunction(arguments: [arg0.jsValue, arg1.jsValue], this: this).jsValue
     }
 
     @discardableResult
-    func callAsFunction(this: JSObject, _ arg0: some ConvertibleToJSValue, _ arg1: some ConvertibleToJSValue, _ arg2: some ConvertibleToJSValue) -> JSValue {
+    func callAsFunction(
+        this: JSObject,
+        _ arg0: some ConvertibleToJSValue,
+        _ arg1: some ConvertibleToJSValue,
+        _ arg2: some ConvertibleToJSValue
+    ) -> JSValue {
         invokeNonThrowingJSFunction(arguments: [arg0.jsValue, arg1.jsValue, arg2.jsValue], this: this).jsValue
+    }
+
+    @discardableResult
+    func callAsFunction(
+        this: JSObject,
+        _ arg0: some ConvertibleToJSValue,
+        _ arg1: some ConvertibleToJSValue,
+        _ arg2: some ConvertibleToJSValue,
+        _ arg3: some ConvertibleToJSValue
+    ) -> JSValue {
+        invokeNonThrowingJSFunction(arguments: [arg0.jsValue, arg1.jsValue, arg2.jsValue, arg3.jsValue], this: this).jsValue
+    }
+
+    @discardableResult
+    func callAsFunction(
+        this: JSObject,
+        _ arg0: some ConvertibleToJSValue,
+        _ arg1: some ConvertibleToJSValue,
+        _ arg2: some ConvertibleToJSValue,
+        _ arg3: some ConvertibleToJSValue,
+        _ arg4: some ConvertibleToJSValue
+    ) -> JSValue {
+        invokeNonThrowingJSFunction(arguments: [arg0.jsValue, arg1.jsValue, arg2.jsValue, arg3.jsValue, arg4.jsValue], this: this).jsValue
+    }
+
+    @discardableResult
+    func callAsFunction(
+        this: JSObject,
+        _ arg0: some ConvertibleToJSValue,
+        _ arg1: some ConvertibleToJSValue,
+        _ arg2: some ConvertibleToJSValue,
+        _ arg3: some ConvertibleToJSValue,
+        _ arg4: some ConvertibleToJSValue,
+        _ arg5: some ConvertibleToJSValue
+    ) -> JSValue {
+        invokeNonThrowingJSFunction(arguments: [arg0.jsValue, arg1.jsValue, arg2.jsValue, arg3.jsValue, arg4.jsValue, arg5.jsValue], this: this).jsValue
+    }
+
+    @discardableResult
+    func callAsFunction(
+        this: JSObject,
+        _ arg0: some ConvertibleToJSValue,
+        _ arg1: some ConvertibleToJSValue,
+        _ arg2: some ConvertibleToJSValue,
+        _ arg3: some ConvertibleToJSValue,
+        _ arg4: some ConvertibleToJSValue,
+        _ arg5: some ConvertibleToJSValue,
+        _ arg6: some ConvertibleToJSValue
+    ) -> JSValue {
+        invokeNonThrowingJSFunction(arguments: [arg0.jsValue, arg1.jsValue, arg2.jsValue, arg3.jsValue, arg4.jsValue, arg5.jsValue, arg6.jsValue], this: this).jsValue
     }
 
     @discardableResult
@@ -203,13 +269,66 @@ public extension JSFunction {
     }
 
     @discardableResult
-    func callAsFunction(_ arg0: some ConvertibleToJSValue, _ arg1: some ConvertibleToJSValue) -> JSValue {
+    func callAsFunction(
+        _ arg0: some ConvertibleToJSValue,
+        _ arg1: some ConvertibleToJSValue
+    ) -> JSValue {
         invokeNonThrowingJSFunction(arguments: [arg0.jsValue, arg1.jsValue]).jsValue
     }
 
     @discardableResult
-    func callAsFunction(_ arg0: some ConvertibleToJSValue, _ arg1: some ConvertibleToJSValue, _ arg2: some ConvertibleToJSValue) -> JSValue {
+    func callAsFunction(
+        _ arg0: some ConvertibleToJSValue,
+        _ arg1: some ConvertibleToJSValue,
+        _ arg2: some ConvertibleToJSValue
+    ) -> JSValue {
         invokeNonThrowingJSFunction(arguments: [arg0.jsValue, arg1.jsValue, arg2.jsValue]).jsValue
+    }
+
+    @discardableResult
+    func callAsFunction(
+        _ arg0: some ConvertibleToJSValue,
+        _ arg1: some ConvertibleToJSValue,
+        _ arg2: some ConvertibleToJSValue,
+        _ arg3: some ConvertibleToJSValue
+    ) -> JSValue {
+        invokeNonThrowingJSFunction(arguments: [arg0.jsValue, arg1.jsValue, arg2.jsValue, arg3.jsValue]).jsValue
+    }
+
+    @discardableResult
+    func callAsFunction(
+        _ arg0: some ConvertibleToJSValue,
+        _ arg1: some ConvertibleToJSValue,
+        _ arg2: some ConvertibleToJSValue,
+        _ arg3: some ConvertibleToJSValue,
+        _ arg4: some ConvertibleToJSValue
+    ) -> JSValue {
+        invokeNonThrowingJSFunction(arguments: [arg0.jsValue, arg1.jsValue, arg2.jsValue, arg3.jsValue, arg4.jsValue]).jsValue
+    }
+
+    @discardableResult
+    func callAsFunction(
+        _ arg0: some ConvertibleToJSValue,
+        _ arg1: some ConvertibleToJSValue,
+        _ arg2: some ConvertibleToJSValue,
+        _ arg3: some ConvertibleToJSValue,
+        _ arg4: some ConvertibleToJSValue,
+        _ arg5: some ConvertibleToJSValue
+    ) -> JSValue {
+        invokeNonThrowingJSFunction(arguments: [arg0.jsValue, arg1.jsValue, arg2.jsValue, arg3.jsValue, arg4.jsValue, arg5.jsValue]).jsValue
+    }
+
+    @discardableResult
+    func callAsFunction(
+        _ arg0: some ConvertibleToJSValue,
+        _ arg1: some ConvertibleToJSValue,
+        _ arg2: some ConvertibleToJSValue,
+        _ arg3: some ConvertibleToJSValue,
+        _ arg4: some ConvertibleToJSValue,
+        _ arg5: some ConvertibleToJSValue,
+        _ arg6: some ConvertibleToJSValue
+    ) -> JSValue {
+        invokeNonThrowingJSFunction(arguments: [arg0.jsValue, arg1.jsValue, arg2.jsValue, arg3.jsValue, arg4.jsValue, arg5.jsValue, arg6.jsValue]).jsValue
     }
 
     func new() -> JSObject {
@@ -220,19 +339,60 @@ public extension JSFunction {
         new(arguments: [arg0.jsValue])
     }
 
-    func new(_ arg0: some ConvertibleToJSValue, _ arg1: some ConvertibleToJSValue) -> JSObject {
+    func new(
+        _ arg0: some ConvertibleToJSValue,
+        _ arg1: some ConvertibleToJSValue
+    ) -> JSObject {
         new(arguments: [arg0.jsValue, arg1.jsValue])
     }
 
-    func new(_ arg0: some ConvertibleToJSValue, _ arg1: some ConvertibleToJSValue, _ arg2: some ConvertibleToJSValue) -> JSObject {
+    func new(
+        _ arg0: some ConvertibleToJSValue,
+        _ arg1: some ConvertibleToJSValue,
+        _ arg2: some ConvertibleToJSValue
+    ) -> JSObject {
         new(arguments: [arg0.jsValue, arg1.jsValue, arg2.jsValue])
     }
 
-    func new(_ arg0: some ConvertibleToJSValue, _ arg1: some ConvertibleToJSValue, _ arg2: some ConvertibleToJSValue, _ arg3: some ConvertibleToJSValue) -> JSObject {
+    func new(
+        _ arg0: some ConvertibleToJSValue,
+        _ arg1: some ConvertibleToJSValue,
+        _ arg2: some ConvertibleToJSValue,
+        _ arg3: some ConvertibleToJSValue
+    ) -> JSObject {
         new(arguments: [arg0.jsValue, arg1.jsValue, arg2.jsValue, arg3.jsValue])
     }
 
-    func new(_ arg0: some ConvertibleToJSValue, _ arg1: some ConvertibleToJSValue, _ arg2: some ConvertibleToJSValue, _ arg3: some ConvertibleToJSValue, _ arg4: some ConvertibleToJSValue, _ arg5: some ConvertibleToJSValue, _ arg6: some ConvertibleToJSValue) -> JSObject {
+    func new(
+        _ arg0: some ConvertibleToJSValue,
+        _ arg1: some ConvertibleToJSValue,
+        _ arg2: some ConvertibleToJSValue,
+        _ arg3: some ConvertibleToJSValue,
+        _ arg4: some ConvertibleToJSValue
+    ) -> JSObject {
+        new(arguments: [arg0.jsValue, arg1.jsValue, arg2.jsValue, arg3.jsValue, arg4.jsValue])
+    }
+
+    func new(
+        _ arg0: some ConvertibleToJSValue,
+        _ arg1: some ConvertibleToJSValue,
+        _ arg2: some ConvertibleToJSValue,
+        _ arg3: some ConvertibleToJSValue,
+        _ arg4: some ConvertibleToJSValue,
+        _ arg5: some ConvertibleToJSValue
+    ) -> JSObject {
+        new(arguments: [arg0.jsValue, arg1.jsValue, arg2.jsValue, arg3.jsValue, arg4.jsValue, arg5.jsValue])
+    }
+
+    func new(
+        _ arg0: some ConvertibleToJSValue,
+        _ arg1: some ConvertibleToJSValue,
+        _ arg2: some ConvertibleToJSValue,
+        _ arg3: some ConvertibleToJSValue,
+        _ arg4: some ConvertibleToJSValue,
+        _ arg5: some ConvertibleToJSValue,
+        _ arg6: some ConvertibleToJSValue
+    ) -> JSObject {
         new(arguments: [arg0.jsValue, arg1.jsValue, arg2.jsValue, arg3.jsValue, arg4.jsValue, arg5.jsValue, arg6.jsValue])
     }
 }

--- a/Sources/JavaScriptKit/FundamentalObjects/JSFunction.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSFunction.swift
@@ -228,7 +228,7 @@ public extension JSFunction {
         new(arguments: [arg0.jsValue, arg1.jsValue, arg2.jsValue])
     }
 
-    func new(_ arg0: some ConvertibleToJSValue, _ arg1: some ConvertibleToJSValue, _ arg2: some ConvertibleToJSValue, arg3: some ConvertibleToJSValue) -> JSObject {
+    func new(_ arg0: some ConvertibleToJSValue, _ arg1: some ConvertibleToJSValue, _ arg2: some ConvertibleToJSValue, _ arg3: some ConvertibleToJSValue) -> JSObject {
         new(arguments: [arg0.jsValue, arg1.jsValue, arg2.jsValue, arg3.jsValue])
     }
 

--- a/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
@@ -298,7 +298,14 @@ public class JSThrowingObject {
 
 
 #if hasFeature(Embedded)
-// NOTE: once embedded supports variadic generics, we can remove these overloads
+// Overloads of `JSObject.subscript(_ name: String) -> ((ConvertibleToJSValue...) -> JSValue)?`
+// for 0 through 7 arguments for Embedded Swift.
+//
+// These are required because the `ConvertibleToJSValue...` subscript is not
+// available in Embedded Swift due to lack of support for existentials.
+//
+// NOTE: Once Embedded Swift supports parameter packs/variadic generics, we can
+// replace all of these with a single method that takes a generic pack.
 public extension JSObject {
     @_disfavoredOverload
     subscript(dynamicMember name: String) -> (() -> JSValue)? {
@@ -315,9 +322,77 @@ public extension JSObject {
     }
 
     @_disfavoredOverload
-    subscript<A0: ConvertibleToJSValue, A1: ConvertibleToJSValue>(dynamicMember name: String) -> ((A0, A1) -> JSValue)? {
+    subscript<
+        A0: ConvertibleToJSValue,
+        A1: ConvertibleToJSValue
+    >(dynamicMember name: String) -> ((A0, A1) -> JSValue)? {
         self[name].function.map { function in 
             { function(this: self, $0, $1) }
+        }
+    }
+
+    @_disfavoredOverload
+    subscript<
+        A0: ConvertibleToJSValue,
+        A1: ConvertibleToJSValue,
+        A2: ConvertibleToJSValue
+    >(dynamicMember name: String) -> ((A0, A1, A2) -> JSValue)? {
+        self[name].function.map { function in
+            { function(this: self, $0, $1, $2) }
+        }
+    }
+
+    @_disfavoredOverload
+    subscript<
+        A0: ConvertibleToJSValue,
+        A1: ConvertibleToJSValue,
+        A2: ConvertibleToJSValue,
+        A3: ConvertibleToJSValue
+    >(dynamicMember name: String) -> ((A0, A1, A2, A3) -> JSValue)? {
+        self[name].function.map { function in
+            { function(this: self, $0, $1, $2, $3) }
+        }
+    }
+
+    @_disfavoredOverload
+    subscript<
+        A0: ConvertibleToJSValue,
+        A1: ConvertibleToJSValue,
+        A2: ConvertibleToJSValue,
+        A3: ConvertibleToJSValue,
+        A4: ConvertibleToJSValue
+    >(dynamicMember name: String) -> ((A0, A1, A2, A3, A4) -> JSValue)? {
+        self[name].function.map { function in
+            { function(this: self, $0, $1, $2, $3, $4) }
+        }
+    }
+
+    @_disfavoredOverload
+    subscript<
+        A0: ConvertibleToJSValue,
+        A1: ConvertibleToJSValue,
+        A2: ConvertibleToJSValue,
+        A3: ConvertibleToJSValue,
+        A4: ConvertibleToJSValue,
+        A5: ConvertibleToJSValue
+    >(dynamicMember name: String) -> ((A0, A1, A2, A3, A4, A5) -> JSValue)? {
+        self[name].function.map { function in
+            { function(this: self, $0, $1, $2, $3, $4, $5) }
+        }
+    }
+
+    @_disfavoredOverload
+    subscript<
+        A0: ConvertibleToJSValue,
+        A1: ConvertibleToJSValue,
+        A2: ConvertibleToJSValue,
+        A3: ConvertibleToJSValue,
+        A4: ConvertibleToJSValue,
+        A5: ConvertibleToJSValue,
+        A6: ConvertibleToJSValue
+    >(dynamicMember name: String) -> ((A0, A1, A2, A3, A4, A5, A6) -> JSValue)? {
+        self[name].function.map { function in
+            { function(this: self, $0, $1, $2, $3, $4, $5, $6) }
         }
     }
 }

--- a/Sources/JavaScriptKit/JSValue.swift
+++ b/Sources/JavaScriptKit/JSValue.swift
@@ -272,9 +272,17 @@ extension JSValue: CustomStringConvertible {
 }
 
 #if hasFeature(Embedded)
+// Overloads of `JSValue.subscript(dynamicMember name: String) -> ((ConvertibleToJSValue...) -> JSValue)`
+// for 0 through 7 arguments for Embedded Swift.
+//
+// These are required because the `ConvertibleToJSValue...` subscript is not
+// available in Embedded Swift due to lack of support for existentials.
+//
+// Note: Once Embedded Swift supports parameter packs/variadic generics, we can
+// replace all of these with a single method that takes a generic pack.
 public extension JSValue {
     @_disfavoredOverload
-    subscript(dynamicMember name: String) -> (() -> JSValue) { 
+    subscript(dynamicMember name: String) -> (() -> JSValue) {
         object![dynamicMember: name]!
     }
 
@@ -284,7 +292,65 @@ public extension JSValue {
     }
 
     @_disfavoredOverload
-    subscript<A0: ConvertibleToJSValue, A1: ConvertibleToJSValue>(dynamicMember name: String) -> ((A0, A1) -> JSValue) {
+    subscript<
+        A0: ConvertibleToJSValue,
+        A1: ConvertibleToJSValue
+    >(dynamicMember name: String) -> ((A0, A1) -> JSValue) {
+        object![dynamicMember: name]!
+    }
+
+    @_disfavoredOverload
+    subscript<
+        A0: ConvertibleToJSValue,
+        A1: ConvertibleToJSValue,
+        A2: ConvertibleToJSValue
+    >(dynamicMember name: String) -> ((A0, A1, A2) -> JSValue) {
+        object![dynamicMember: name]!
+    }
+
+    @_disfavoredOverload
+    subscript<
+        A0: ConvertibleToJSValue,
+        A1: ConvertibleToJSValue,
+        A2: ConvertibleToJSValue,
+        A3: ConvertibleToJSValue
+    >(dynamicMember name: String) -> ((A0, A1, A2, A3) -> JSValue) {
+        object![dynamicMember: name]!
+    }
+
+    @_disfavoredOverload
+    subscript<
+        A0: ConvertibleToJSValue,
+        A1: ConvertibleToJSValue,
+        A2: ConvertibleToJSValue,
+        A3: ConvertibleToJSValue,
+        A4: ConvertibleToJSValue
+    >(dynamicMember name: String) -> ((A0, A1, A2, A3, A4) -> JSValue) {
+        object![dynamicMember: name]!
+    }
+
+    @_disfavoredOverload
+    subscript<
+        A0: ConvertibleToJSValue,
+        A1: ConvertibleToJSValue,
+        A2: ConvertibleToJSValue,
+        A3: ConvertibleToJSValue,
+        A4: ConvertibleToJSValue,
+        A5: ConvertibleToJSValue
+    >(dynamicMember name: String) -> ((A0, A1, A2, A3, A4, A5) -> JSValue) {
+        object![dynamicMember: name]!
+    }
+
+    @_disfavoredOverload
+    subscript<
+        A0: ConvertibleToJSValue,
+        A1: ConvertibleToJSValue,
+        A2: ConvertibleToJSValue,
+        A3: ConvertibleToJSValue,
+        A4: ConvertibleToJSValue,
+        A5: ConvertibleToJSValue,
+        A6: ConvertibleToJSValue
+    >(dynamicMember name: String) -> ((A0, A1, A2, A3, A4, A5, A6) -> JSValue) {
         object![dynamicMember: name]!
     }
 }


### PR DESCRIPTION
This fixes #279.

Notes:

- The choice up to how many aguments to support before we can replace everything with a single varadic generics funtion is arbitrary. I chose to go up to 7 arguments because `JSFunction.new` already had some overloads with up to 7 arguments, so this seemed the most consistent.

- I used a different code style for the new overloads where each generic parameter is put on its own line. I'm aware that this doesn't follow the project's code style, but I found the alternative (the full function signature on a single line) pretty much unreadable. Please let me know if you want me to change this.

- I didn't add any tests for the new functionality because the existing test suite isn't built/executed in Embedded Swift mode anyway, so the new code wouldn't even be built. I did a quick test locally to ensure the overloads work. I hope this is OK, but please let me know if you want more. If so, we have to integrate an Embedded Swift build into the testing process.