### PR TITLE
CI: Use Swift SDK by default

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -6,17 +6,15 @@ on:
 jobs:
   test:
     name: Check source code compatibility
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container: swift:6.0.3
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: swiftwasm/setup-swiftwasm@v1
-        with:
-          swift-version: wasm-6.0.3-RELEASE
+      - uses: swiftwasm/setup-swiftwasm@v2
       - name: Run Test
         run: |
           set -eux
-          make bootstrap
           cd Examples/Basic
-          swift build --triple wasm32-unknown-wasi --static-swift-stdlib
-          swift build --triple wasm32-unknown-wasi -Xswiftc -DJAVASCRIPTKIT_WITHOUT_WEAKREFS --static-swift-stdlib
+          swift build --swift-sdk wasm32-unknown-wasi --static-swift-stdlib
+          swift build --swift-sdk wasm32-unknown-wasi -Xswiftc -DJAVASCRIPTKIT_WITHOUT_WEAKREFS --static-swift-stdlib

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -4,13 +4,15 @@ on: [pull_request]
 
 jobs:
   perf:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container: swift:6.0.3
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: swiftwasm/setup-swiftwasm@v1
-        with:
-          swift-version: wasm-5.9.1-RELEASE
+      - uses: swiftwasm/setup-swiftwasm@v2
+      - name: Install dependencies
+        run: |
+          apt-get update && apt-get install make nodejs npm -y
       - name: Run Benchmark
         run: |
           make bootstrap

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -4,15 +4,14 @@ on: [pull_request]
 
 jobs:
   perf:
-    runs-on: ubuntu-latest
-    container: swift:6.0.3
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - uses: ./.github/actions/install-swift
+        with:
+          download-url: https://download.swift.org/swift-6.0.3-release/ubuntu2404/swift-6.0.3-RELEASE/swift-6.0.3-RELEASE-ubuntu24.04.tar.gz
       - uses: swiftwasm/setup-swiftwasm@v2
-      - name: Install dependencies
-        run: |
-          apt-get update && apt-get install make nodejs npm -y
       - name: Run Benchmark
         run: |
           make bootstrap

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,38 +9,17 @@ jobs:
     strategy:
       matrix:
         entry:
-          # Ensure that all host can install toolchain, build project, and run tests
-          - { os: macos-14,     toolchain: wasm-5.9.1-RELEASE, wasi-backend: Node, xcode: Xcode_15.2.app }
-          - { os: ubuntu-22.04, toolchain: wasm-5.9.1-RELEASE, wasi-backend: Node }
-          - { os: ubuntu-22.04, toolchain: wasm-5.10.0-RELEASE, wasi-backend: Node }
-
-          # Ensure that test succeeds with all toolchains and wasi backend combinations
-          - { os: ubuntu-20.04, toolchain: wasm-5.10.0-RELEASE, wasi-backend: Node }
-          - { os: ubuntu-20.04, toolchain: wasm-5.9.1-RELEASE, wasi-backend: MicroWASI }
-          - { os: ubuntu-20.04, toolchain: wasm-5.10.0-RELEASE, wasi-backend: MicroWASI }
           - os: ubuntu-22.04
             toolchain:
               download-url: https://download.swift.org/swift-6.0.2-release/ubuntu2204/swift-6.0.2-RELEASE/swift-6.0.2-RELEASE-ubuntu22.04.tar.gz
-            swift-sdk:
-              id: 6.0.2-RELEASE-wasm32-unknown-wasi
-              download-url: "https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.0.2-RELEASE/swift-wasm-6.0.2-RELEASE-wasm32-unknown-wasi.artifactbundle.zip"
-              checksum: "6ffedb055cb9956395d9f435d03d53ebe9f6a8d45106b979d1b7f53358e1dcb4"
             wasi-backend: Node
           - os: ubuntu-22.04
             toolchain:
               download-url: https://download.swift.org/development/ubuntu2204/swift-DEVELOPMENT-SNAPSHOT-2024-10-30-a/swift-DEVELOPMENT-SNAPSHOT-2024-10-30-a-ubuntu22.04.tar.gz
-            swift-sdk:
-              id: DEVELOPMENT-SNAPSHOT-2024-10-31-a-wasm32-unknown-wasi
-              download-url: "https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-10-31-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-10-31-a-wasm32-unknown-wasi.artifactbundle.zip"
-              checksum: "e42546397786ea6eaec2d9c07f9118a6f3428784cf3df3840a369f19700c1a69"
             wasi-backend: Node
           - os: ubuntu-22.04
             toolchain:
               download-url: https://download.swift.org/development/ubuntu2204/swift-DEVELOPMENT-SNAPSHOT-2024-10-30-a/swift-DEVELOPMENT-SNAPSHOT-2024-10-30-a-ubuntu22.04.tar.gz
-            swift-sdk:
-              id: DEVELOPMENT-SNAPSHOT-2024-10-31-a-wasm32-unknown-wasip1-threads
-              download-url: "https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-10-31-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-10-31-a-wasm32-unknown-wasip1-threads.artifactbundle.zip"
-              checksum: "17dbbe61af6ca09c92ee2d68a56d5716530428e28c4c8358aa860cc4fcdc91ae"
             wasi-backend: Node
 
     runs-on: ${{ matrix.entry.os }}
@@ -49,22 +28,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Select SDKROOT
-        if: ${{ matrix.entry.xcode }}
-        run: sudo xcode-select -s /Applications/${{ matrix.entry.xcode }}
-      - uses: swiftwasm/setup-swiftwasm@v1
-        if: ${{ matrix.entry.swift-sdk == null }}
-        with:
-          swift-version: ${{ matrix.entry.toolchain }}
       - uses: ./.github/actions/install-swift
-        if: ${{ matrix.entry.swift-sdk }}
         with:
           download-url: ${{ matrix.entry.toolchain.download-url }}
-      - name: Install Swift SDK
-        if: ${{ matrix.entry.swift-sdk }}
-        run: |
-          swift sdk install "${{ matrix.entry.swift-sdk.download-url }}" --checksum "${{ matrix.entry.swift-sdk.checksum }}"
-          echo "SWIFT_SDK_ID=${{ matrix.entry.swift-sdk.id }}" >> $GITHUB_ENV
+      - uses: swiftwasm/setup-swiftwasm@v2
+        id: setup-swiftwasm
+      - name: Configure Swift SDK
+        run: echo "SWIFT_SDK_ID=${{ steps.setup-swiftwasm.outputs.swift-sdk-id }}" >> $GITHUB_ENV
       - run: make bootstrap
       - run: make test
       - run: make unittest

--- a/Examples/Basic/build.sh
+++ b/Examples/Basic/build.sh
@@ -1,1 +1,2 @@
-swift build --swift-sdk DEVELOPMENT-SNAPSHOT-2024-09-20-a-wasm32-unknown-wasi -Xswiftc -Xclang-linker -Xswiftc -mexec-model=reactor -Xlinker --export=__main_argc_argv
+#!/bin/bash
+swift build --swift-sdk "${SWIFT_SDK_ID:-wasm32-unknown-wasi}" -Xswiftc -Xclang-linker -Xswiftc -mexec-model=reactor -Xlinker --export=__main_argc_argv

--- a/IntegrationTests/package-lock.json
+++ b/IntegrationTests/package-lock.json
@@ -11,7 +11,7 @@
     },
     "..": {
       "name": "javascript-kit-swift",
-      "version": "0.19.2",
+      "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^8.3.1",

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,7 @@
 MAKEFILE_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
-ifeq ($(SWIFT_SDK_ID),)
-SWIFT_BUILD_FLAGS := --triple wasm32-unknown-wasi
-else
+SWIFT_SDK_ID ?= wasm32-unknown-wasi
 SWIFT_BUILD_FLAGS := --swift-sdk $(SWIFT_SDK_ID)
-endif
 
 .PHONY: bootstrap
 bootstrap:


### PR DESCRIPTION
In other words, drop toolchain-style installation support.

https://github.com/swiftwasm/swift/issues/5604