### PR TITLE
Use `@_expose(wasm)` instead of `__attribute__((export_name))` and `@_cdecl` hack

### DIFF
--- a/Examples/Embedded/Sources/EmbeddedApp/_thingsThatShouldNotBeNeeded.swift
+++ b/Examples/Embedded/Sources/EmbeddedApp/_thingsThatShouldNotBeNeeded.swift
@@ -1,12 +1,5 @@
 import JavaScriptKit
 
-// NOTE: it seems the embedded tree shaker gets rid of these exports if they are not used somewhere
-func _i_need_to_be_here_for_wasm_exports_to_work() {
-    _ = _swjs_library_features
-    _ = _swjs_call_host_function
-    _ = _swjs_free_host_function
-}
-
 // TODO: why do I need this? and surely this is not ideal... figure this out, or at least have this come from a C lib
 @_cdecl("strlen")
 func strlen(_ s: UnsafePointer<Int8>) -> Int {

--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -56,14 +56,6 @@ export class SwiftRuntime {
                 `
             );
         }
-        if (this.exports.swjs_library_version() != this.version) {
-            throw new Error(
-                `The versions of JavaScriptKit are incompatible.
-                WebAssembly runtime ${this.exports.swjs_library_version()} != JS runtime ${
-                    this.version
-                }`
-            );
-        }
     }
 
     main() {

--- a/Runtime/src/types.ts
+++ b/Runtime/src/types.ts
@@ -7,7 +7,6 @@ export type JavaScriptValueKind = number;
 export type JavaScriptValueKindAndFlags = number;
 
 export interface ExportedFunctions {
-    swjs_library_version(): number;
     swjs_library_features(): number;
     swjs_prepare_host_function_call(size: number): pointer;
     swjs_cleanup_host_function_call(argv: pointer): void;

--- a/Sources/JavaScriptKit/Features.swift
+++ b/Sources/JavaScriptKit/Features.swift
@@ -2,17 +2,13 @@ enum LibraryFeatures {
     static let weakRefs: Int32 = 1 << 0
 }
 
-@_cdecl("_library_features")
-func _library_features() -> Int32 {
+@_expose(wasm, "swjs_library_features")
+@_cdecl("_swjs_library_features")
+@available(*, unavailable)
+public func _swjs_library_features() -> Int32 {
     var features: Int32 = 0
 #if !JAVASCRIPTKIT_WITHOUT_WEAKREFS
     features |= LibraryFeatures.weakRefs
 #endif
     return features
 }
-
-#if compiler(>=6.0) && hasFeature(Embedded)
-// cdecls currently don't work in embedded, and expose for wasm only works >=6.0
-@_expose(wasm, "swjs_library_features")
-public func _swjs_library_features() -> Int32 { _library_features() }
-#endif

--- a/Sources/JavaScriptKit/FundamentalObjects/JSClosure.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSClosure.swift
@@ -197,8 +197,10 @@ private func makeAsyncClosure(
 // └─────────────────────┴──────────────────────────┘
 
 /// Returns true if the host function has been already released, otherwise false.
-@_cdecl("_call_host_function_impl")
-func _call_host_function_impl(
+@_expose(wasm, "swjs_call_host_function")
+@_cdecl("_swjs_call_host_function")
+@available(*, unavailable)
+public func _swjs_call_host_function(
     _ hostFuncRef: JavaScriptHostFuncRef,
     _ argv: UnsafePointer<RawJSValue>, _ argc: Int32,
     _ callbackFuncRef: JavaScriptObjectRef
@@ -231,9 +233,10 @@ extension JSClosure {
     }
 }
 
-
-@_cdecl("_free_host_function_impl")
-func _free_host_function_impl(_ hostFuncRef: JavaScriptHostFuncRef) {}
+@_expose(wasm, "swjs_free_host_function")
+@_cdecl("_swjs_free_host_function")
+@available(*, unavailable)
+func _swjs_free_host_function(_ hostFuncRef: JavaScriptHostFuncRef) {}
 
 #else
 
@@ -244,25 +247,10 @@ extension JSClosure {
 
 }
 
-@_cdecl("_free_host_function_impl")
-func _free_host_function_impl(_ hostFuncRef: JavaScriptHostFuncRef) {
-    JSClosure.sharedClosures.wrappedValue[hostFuncRef] = nil
-}
-#endif
-
-#if compiler(>=6.0) && hasFeature(Embedded)
-// cdecls currently don't work in embedded, and expose for wasm only works >=6.0
-@_expose(wasm, "swjs_call_host_function")
-public func _swjs_call_host_function(
-        _ hostFuncRef: JavaScriptHostFuncRef,
-        _ argv: UnsafePointer<RawJSValue>, _ argc: Int32,
-        _ callbackFuncRef: JavaScriptObjectRef) -> Bool {
-
-    _call_host_function_impl(hostFuncRef, argv, argc, callbackFuncRef) 
-}
-
 @_expose(wasm, "swjs_free_host_function")
-public func _swjs_free_host_function(_ hostFuncRef: JavaScriptHostFuncRef) {
-    _free_host_function_impl(hostFuncRef)
+@_cdecl("_swjs_free_host_function")
+@available(*, unavailable)
+func _swjs_free_host_function(_ hostFuncRef: JavaScriptHostFuncRef) {
+    JSClosure.sharedClosures.wrappedValue[hostFuncRef] = nil
 }
 #endif

--- a/Sources/JavaScriptKit/Runtime/index.js
+++ b/Sources/JavaScriptKit/Runtime/index.js
@@ -328,10 +328,6 @@
                 -Xswiftc -Xclang-linker -Xswiftc -mexec-model=reactor
                 `);
             }
-            if (this.exports.swjs_library_version() != this.version) {
-                throw new Error(`The versions of JavaScriptKit are incompatible.
-                WebAssembly runtime ${this.exports.swjs_library_version()} != JS runtime ${this.version}`);
-            }
         }
         main() {
             const instance = this.instance;

--- a/Sources/JavaScriptKit/Runtime/index.mjs
+++ b/Sources/JavaScriptKit/Runtime/index.mjs
@@ -322,10 +322,6 @@ class SwiftRuntime {
                 -Xswiftc -Xclang-linker -Xswiftc -mexec-model=reactor
                 `);
         }
-        if (this.exports.swjs_library_version() != this.version) {
-            throw new Error(`The versions of JavaScriptKit are incompatible.
-                WebAssembly runtime ${this.exports.swjs_library_version()} != JS runtime ${this.version}`);
-        }
     }
     main() {
         const instance = this.instance;

--- a/Sources/_CJavaScriptKit/_CJavaScriptKit.c
+++ b/Sources/_CJavaScriptKit/_CJavaScriptKit.c
@@ -13,13 +13,6 @@ extern void *memcpy (void *__restrict, const void *__restrict, size_t);
 #include <stdbool.h>
 
 #endif
-/// The compatibility runtime library version.
-/// Notes: If you change any interface of runtime library, please increment
-/// this and `SwiftRuntime.version` in `./Runtime/src/index.ts`.
-__attribute__((export_name("swjs_library_version")))
-int swjs_library_version(void) {
-    return 708;
-}
 
 __attribute__((export_name("swjs_prepare_host_function_call")))
 void *swjs_prepare_host_function_call(const int argc) {

--- a/Sources/_CJavaScriptKit/_CJavaScriptKit.c
+++ b/Sources/_CJavaScriptKit/_CJavaScriptKit.c
@@ -28,24 +28,6 @@ void swjs_cleanup_host_function_call(void *argv_buffer) {
 // cdecls don't work in Embedded, but @_expose(wasm) can be used with Swift >=6.0
 // the previously used `#if __Embedded` did not play well with SwiftPM (defines needed to be on every target up the chain)
 #ifdef __wasi__
-bool _call_host_function_impl(const JavaScriptHostFuncRef host_func_ref,
-                              const RawJSValue *argv, const int argc,
-                              const JavaScriptObjectRef callback_func);
-
-__attribute__((export_name("swjs_call_host_function")))
-bool swjs_call_host_function(const JavaScriptHostFuncRef host_func_ref,
-                             const RawJSValue *argv, const int argc,
-                             const JavaScriptObjectRef callback_func) {
-    return _call_host_function_impl(host_func_ref, argv, argc, callback_func);
-}
-
-void _free_host_function_impl(const JavaScriptHostFuncRef host_func_ref);
-
-__attribute__((export_name("swjs_free_host_function")))
-void swjs_free_host_function(const JavaScriptHostFuncRef host_func_ref) {
-    _free_host_function_impl(host_func_ref);
-}
-
 int swjs_get_worker_thread_id_cached(void) {
     _Thread_local static int tid = 0;
     if (tid == 0) {

--- a/Sources/_CJavaScriptKit/_CJavaScriptKit.c
+++ b/Sources/_CJavaScriptKit/_CJavaScriptKit.c
@@ -46,13 +46,6 @@ void swjs_free_host_function(const JavaScriptHostFuncRef host_func_ref) {
     _free_host_function_impl(host_func_ref);
 }
 
-int _library_features(void);
-
-__attribute__((export_name("swjs_library_features")))
-int swjs_library_features(void) {
-    return _library_features();
-}
-
 int swjs_get_worker_thread_id_cached(void) {
     _Thread_local static int tid = 0;
     if (tid == 0) {


### PR DESCRIPTION
Symbol references from Swift code to C makes it difficult to properly keep the referenced C definitions. https://github.com/swiftlang/swift/issues/77812