### PR TITLE
Make `JSObject.id` getter inlinable

### DIFF
--- a/Sources/JavaScriptKit/FundamentalObjects/JSClosure.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSClosure.swift
@@ -21,7 +21,7 @@ public class JSOneshotClosure: JSObject, JSClosureProtocol {
 
         // 2. Create a new JavaScript function which calls the given Swift function.
         hostFuncRef = JavaScriptHostFuncRef(bitPattern: ObjectIdentifier(self))
-        id = withExtendedLifetime(JSString(file)) { file in
+        _id = withExtendedLifetime(JSString(file)) { file in
             swjs_create_function(hostFuncRef, line, file.asInternalJSRef())
         }
 
@@ -105,7 +105,7 @@ public class JSClosure: JSFunction, JSClosureProtocol {
 
         // 2. Create a new JavaScript function which calls the given Swift function.
         hostFuncRef = JavaScriptHostFuncRef(bitPattern: ObjectIdentifier(self))
-        id = withExtendedLifetime(JSString(file)) { file in
+        _id = withExtendedLifetime(JSString(file)) { file in
             swjs_create_function(hostFuncRef, line, file.asInternalJSRef())
         }
 

--- a/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
@@ -19,16 +19,20 @@ public class JSObject: Equatable {
     internal static var constructor: JSFunction { _constructor.wrappedValue }
     private static let _constructor = LazyThreadLocal(initialize: { JSObject.global.Object.function! })
 
-    @_spi(JSObject_id)
-    public var id: JavaScriptObjectRef
+    @usableFromInline
+    internal var _id: JavaScriptObjectRef
 
 #if compiler(>=6.1) && _runtime(_multithreaded)
     package let ownerTid: Int32
 #endif
 
     @_spi(JSObject_id)
+    @inlinable
+    public var id: JavaScriptObjectRef { _id }
+
+    @_spi(JSObject_id)
     public init(id: JavaScriptObjectRef) {
-        self.id = id
+        self._id = id
 #if compiler(>=6.1) && _runtime(_multithreaded)
         self.ownerTid = swjs_get_worker_thread_id_cached()
 #endif


### PR DESCRIPTION
This change makes `JSObject.id` getter inlinable. Those who use the API to avoid dynamic member lookup overhead can now benefit from the inlinable getter.