### PR TITLE
Add `--configuration` option to `swift package js` command

### DIFF
--- a/Plugins/PackageToJS/Sources/PackageToJS.swift
+++ b/Plugins/PackageToJS/Sources/PackageToJS.swift
@@ -4,6 +4,8 @@ struct PackageToJS {
     struct PackageOptions {
         /// Path to the output directory
         var outputPath: String?
+        /// The build configuration to use (default: debug)
+        var configuration: String?
         /// Name of the package (default: lowercased Package.swift name)
         var packageName: String?
         /// Whether to explain the build plan (default: false)

--- a/Plugins/PackageToJS/Tests/ExampleTests.swift
+++ b/Plugins/PackageToJS/Tests/ExampleTests.swift
@@ -242,7 +242,7 @@ extension Trait where Self == ConditionTrait {
     @Test(.requireEmbeddedSwift) func embedded() throws {
         try withPackage(at: "Examples/Embedded") { packageDir, runSwift in
             try runSwift(
-                ["package", "--triple", "wasm32-unknown-none-wasm", "-c", "release", "js"],
+                ["package", "--triple", "wasm32-unknown-none-wasm", "js", "-c", "release"],
                 [
                     "JAVASCRIPTKIT_EXPERIMENTAL_EMBEDDED_WASM": "true"
                 ]


### PR DESCRIPTION
If we pass `-c release` as `swift package` option, command plugins will also be built in release configuration, which is not what we want.