### PR TITLE
Add `JSTypedArray.init(buffer:)` initializer

### DIFF
--- a/Tests/JavaScriptKitTests/JSTypedArrayTests.swift
+++ b/Tests/JavaScriptKitTests/JSTypedArrayTests.swift
@@ -97,4 +97,16 @@ final class JSTypedArrayTests: XCTestCase {
 
         XCTAssertEqual(toString(array.jsValue.object!), jsStringify(Array(0..<100)))
     }
+
+    func testInitWithBufferPointer() {
+        let buffer = UnsafeMutableBufferPointer<Float32>.allocate(capacity: 20)
+        defer { buffer.deallocate() }
+        for i in 0..<20 {
+            buffer[i] = Float32(i)
+        }
+        let typedArray = JSTypedArray<Float32>(buffer: UnsafeBufferPointer(buffer))
+        for i in 0..<20 {
+            XCTAssertEqual(typedArray[i], Float32(i))
+        }
+    }
 }


### PR DESCRIPTION
Without this initializer, the only way to create a TypedArray with a UnsafeBufferPointer was to convert it to an Array first and then create a new TypedArray from it.