### PR TITLE
Add `JSTypedArray.copyMemory(to:)` method

### DIFF
--- a/Tests/JavaScriptKitTests/JSTypedArrayTests.swift
+++ b/Tests/JavaScriptKitTests/JSTypedArrayTests.swift
@@ -109,4 +109,18 @@ final class JSTypedArrayTests: XCTestCase {
             XCTAssertEqual(typedArray[i], Float32(i))
         }
     }
+
+    func testCopyMemory() {
+        let array = JSTypedArray<Int>(length: 100)
+        for i in 0..<100 {
+            array[i] = i
+        }
+        let destination = UnsafeMutableBufferPointer<Int>.allocate(capacity: 100)
+        defer { destination.deallocate() }
+        array.copyMemory(to: destination)
+
+        for i in 0..<100 {
+            XCTAssertEqual(destination[i], i)
+        }
+    }
 }


### PR DESCRIPTION
This method allows copying the contents of a typed array to a Swift memory buffer.