### PR TITLE
PackageToJS: Inherit `swift package -c` configuration by default

### DIFF
--- a/Plugins/PackageToJS/Sources/PackageToJSPlugin.swift
+++ b/Plugins/PackageToJS/Sources/PackageToJSPlugin.swift
@@ -323,7 +323,7 @@ struct PackageToJSPlugin: CommandPlugin {
             }
             buildConfiguration = _buildConfiguration
         } else {
-            buildConfiguration = .debug
+            buildConfiguration = .inherit
         }
         var parameters = PackageManager.BuildParameters(
             configuration: buildConfiguration,


### PR DESCRIPTION
https://github.com/swiftwasm/JavaScriptKit/pull/309 introduced `-c` option to the plugin side in addition to the `swift package`'s one. However `swift package -c release js` was building with release config before 0.25.0 but it started to build with debug config as the default in 0.25.0. This change makes the plugin to respect the `swift package`'s one if `-c` is not specified after `js` plugin name