### PR TITLE
Fix node version diagnostic handling on test harness

### DIFF
--- a/Plugins/PackageToJS/Templates/bin/test.js
+++ b/Plugins/PackageToJS/Templates/bin/test.js
@@ -38,35 +38,35 @@ const args = parseArgs({
 
 const harnesses = {
     node: async ({ preludeScript }) => {
-        let options = await nodePlatform.defaultNodeSetup({
-            args: testFrameworkArgs,
-            onExit: (code) => {
-                if (code !== 0) { return }
-                // Extract the coverage file from the wasm module
-                const filePath = "default.profraw"
-                const destinationPath = args.values["coverage-file"] ?? filePath
-                const profraw = options.wasi.extractFile?.(filePath)
-                if (profraw) {
-                    console.log(`Saved ${filePath} to ${destinationPath}`);
-                    writeFileSync(destinationPath, profraw);
-                }
-            },
-            /* #if USE_SHARED_MEMORY */
-            spawnWorker: nodePlatform.createDefaultWorkerFactory(preludeScript)
-            /* #endif */
-        })
-        if (preludeScript) {
-            const prelude = await import(preludeScript)
-            if (prelude.setupOptions) {
-                options = prelude.setupOptions(options, { isMainThread: true })
-            }
-        }
         try {
+            let options = await nodePlatform.defaultNodeSetup({
+                args: testFrameworkArgs,
+                onExit: (code) => {
+                    if (code !== 0) { return }
+                    // Extract the coverage file from the wasm module
+                    const filePath = "default.profraw"
+                    const destinationPath = args.values["coverage-file"] ?? filePath
+                    const profraw = options.wasi.extractFile?.(filePath)
+                    if (profraw) {
+                        console.log(`Saved ${filePath} to ${destinationPath}`);
+                        writeFileSync(destinationPath, profraw);
+                    }
+                },
+                /* #if USE_SHARED_MEMORY */
+                spawnWorker: nodePlatform.createDefaultWorkerFactory(preludeScript)
+                /* #endif */
+            })
+            if (preludeScript) {
+                const prelude = await import(preludeScript)
+                if (prelude.setupOptions) {
+                    options = prelude.setupOptions(options, { isMainThread: true })
+                }
+            }
             await instantiate(options)
         } catch (e) {
             if (e instanceof WebAssembly.CompileError) {
                 // Check Node.js major version
-                const nodeVersion = process.version.split(".")[0]
+                const nodeVersion = process.versions.node.split(".")[0]
                 const minNodeVersion = 20
                 if (nodeVersion < minNodeVersion) {
                     console.error(`Hint: Node.js version ${nodeVersion} is not supported, please use version ${minNodeVersion} or later.`)


### PR DESCRIPTION
The CompileError usually happens during `defaultNodeSetup`, so we should catch it there. Also `process.version` is a string with a `v` prefix, so we should use `process.versions.node`, which doesn't have the prefix instead.