### PR TITLE
Export `UnsafeEventLoopYield` error type

### DIFF
--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -749,4 +749,4 @@ export class SwiftRuntime {
 /// This error is thrown to unwind the call stack of the Swift program and return the control to
 /// the JavaScript side. Otherwise, the `swift_task_asyncMainDrainQueue` ends up with `abort()`
 /// because the event loop expects `exit()` call before the end of the event loop.
-class UnsafeEventLoopYield extends Error {}
+export class UnsafeEventLoopYield extends Error {}


### PR DESCRIPTION
Some apps wrap instance.exports and monitor
exceptions thrown during execution of Wasm program but `UnsafeEventLoopYield` is not something they
want to report, so they need to be able to filter them out. However, they cannot use `UnsafeEventLoopYield` type name because some bundlers can rename it.
We should export it to allow them not to depend on the constructor name