### PR TITLE
Fix some Embedded Swift issues in JavaScriptEventLoop

### DIFF
--- a/Sources/JavaScriptEventLoop/JSSending.swift
+++ b/Sources/JavaScriptEventLoop/JSSending.swift
@@ -1,3 +1,4 @@
+import _Concurrency
 @_spi(JSObject_id) import JavaScriptKit
 import _CJavaScriptKit
 

--- a/Sources/JavaScriptEventLoop/JobQueue.swift
+++ b/Sources/JavaScriptEventLoop/JobQueue.swift
@@ -2,6 +2,7 @@
 // The current implementation is much simple to be easily debugged, but should be re-implemented
 // using priority queue ideally.
 
+import _Concurrency
 import _CJavaScriptEventLoop
 
 #if compiler(>=5.5)

--- a/Sources/JavaScriptEventLoop/WebWorkerDedicatedExecutor.swift
+++ b/Sources/JavaScriptEventLoop/WebWorkerDedicatedExecutor.swift
@@ -1,5 +1,7 @@
+#if !hasFeature(Embedded)
 import JavaScriptKit
 import _CJavaScriptEventLoop
+import _Concurrency
 
 #if canImport(Synchronization)
 import Synchronization
@@ -60,3 +62,4 @@ public final class WebWorkerDedicatedExecutor: SerialExecutor {
         self.underlying.enqueue(job)
     }
 }
+#endif

--- a/Sources/JavaScriptEventLoop/WebWorkerTaskExecutor.swift
+++ b/Sources/JavaScriptEventLoop/WebWorkerTaskExecutor.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.0)  // `TaskExecutor` is available since Swift 6.0
+#if compiler(>=6.0) && !hasFeature(Embedded) // `TaskExecutor` is available since Swift 6.0, no multi-threading for embedded Wasm yet.
 
 import JavaScriptKit
 import _CJavaScriptKit


### PR DESCRIPTION
This change fixes some of the issues that appear when building this library with Embedded Swift. It adds missing concurrency imports and avoids use of throwing tasks that are not supported in Embedded Swift. Standard Swift's `Result` type is used instead to express error throwing.