### PR TITLE
Unify the installGlobalExecutor process for JavaScriptEventLoop and WebWorkerTaskExecutor

### DIFF
--- a/Sources/JavaScriptEventLoopTestSupport/JavaScriptEventLoopTestSupport.swift
+++ b/Sources/JavaScriptEventLoopTestSupport/JavaScriptEventLoopTestSupport.swift
@@ -27,11 +27,6 @@ import JavaScriptEventLoop
 func swift_javascriptkit_activate_js_executor_impl() {
     MainActor.assumeIsolated {
         JavaScriptEventLoop.installGlobalExecutor()
-        #if canImport(wasi_pthread) && compiler(>=6.1) && _runtime(_multithreaded)
-        if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
-            WebWorkerTaskExecutor.installGlobalExecutor()
-        }
-        #endif
     }
 }
 

--- a/Sources/_CJavaScriptKit/include/_CJavaScriptKit.h
+++ b/Sources/_CJavaScriptKit/include/_CJavaScriptKit.h
@@ -326,6 +326,8 @@ IMPORT_JS_FUNCTION(swjs_get_worker_thread_id, int, (void))
 
 IMPORT_JS_FUNCTION(swjs_create_object, JavaScriptObjectRef, (void))
 
+#define SWJS_MAIN_THREAD_ID -1
+
 int swjs_get_worker_thread_id_cached(void);
 
 /// Requests sending a JavaScript object to another worker thread.


### PR DESCRIPTION
This is a preparation for the upcoming "Custom main and global executors"