### PR TITLE
Fix `JavaScriptEventLoop` not building with Embedded Swift

### DIFF
--- a/Sources/JavaScriptEventLoop/JavaScriptEventLoop.swift
+++ b/Sources/JavaScriptEventLoop/JavaScriptEventLoop.swift
@@ -2,10 +2,7 @@ import JavaScriptKit
 import _Concurrency
 import _CJavaScriptEventLoop
 import _CJavaScriptKit
-
-#if hasFeature(Embedded)
 import Synchronization
-#endif
 
 // NOTE: `@available` annotations are semantically wrong, but they make it easier to develop applications targeting WebAssembly in Xcode.
 
@@ -109,12 +106,7 @@ public final class JavaScriptEventLoop: SerialExecutor, @unchecked Sendable {
         return eventLoop
     }
 
-    #if !hasFeature(Embedded)
-    @MainActor
-    private static var didInstallGlobalExecutor = false
-    #else
     private static let didInstallGlobalExecutor = Atomic<Bool>(false)
-    #endif
 
     /// Set JavaScript event loop based executor to be the global executor
     /// Note that this should be called before any of the jobs are created.
@@ -122,26 +114,13 @@ public final class JavaScriptEventLoop: SerialExecutor, @unchecked Sendable {
     /// introduced officially. See also [a draft proposal for custom
     /// executors](https://github.com/rjmccall/swift-evolution/blob/custom-executors/proposals/0000-custom-executors.md#the-default-global-concurrent-executor)
     public static func installGlobalExecutor() {
-        #if !hasFeature(Embedded)
-        MainActor.assumeIsolated {
-            Self.installGlobalExecutorIsolated()
-        }
-        #else
         Self.installGlobalExecutorIsolated()
-        #endif
     }
 
-    #if !hasFeature(Embedded)
-    @MainActor
-    #endif
     private static func installGlobalExecutorIsolated() {
-        #if !hasFeature(Embedded)
-        guard !didInstallGlobalExecutor else { return }
-        #else
         guard !didInstallGlobalExecutor.load(ordering: .sequentiallyConsistent) else {
             return
         }
-        #endif
 
         #if compiler(>=5.9)
         typealias swift_task_asyncMainDrainQueue_hook_Fn = @convention(thin) (
@@ -211,11 +190,7 @@ public final class JavaScriptEventLoop: SerialExecutor, @unchecked Sendable {
             to: UnsafeMutableRawPointer?.self
         )
 
-        #if !hasFeature(Embedded)
-        didInstallGlobalExecutor = true
-        #else
         didInstallGlobalExecutor.store(true, ordering: .sequentiallyConsistent)
-        #endif
     }
 
     private func enqueue(_ job: UnownedJob, withDelay nanoseconds: UInt64) {

--- a/Sources/JavaScriptKit/BasicObjects/JSPromise.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSPromise.swift
@@ -93,7 +93,7 @@ public final class JSPromise: JSBridgedClass {
         return JSPromise(unsafelyWrapping: jsObject.then!(closure).object!)
     }
 
-    #if compiler(>=5.5)
+    #if compiler(>=5.5) && (!hasFeature(Embedded) || os(WASI))
     /// Schedules the `success` closure to be invoked on successful completion of `self`.
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     @discardableResult
@@ -122,7 +122,7 @@ public final class JSPromise: JSBridgedClass {
         return JSPromise(unsafelyWrapping: jsObject.then!(successClosure, failureClosure).object!)
     }
 
-    #if compiler(>=5.5)
+    #if compiler(>=5.5) && (!hasFeature(Embedded) || os(WASI))
     /// Schedules the `success` closure to be invoked on successful completion of `self`.
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     @discardableResult
@@ -153,7 +153,7 @@ public final class JSPromise: JSBridgedClass {
         return .init(unsafelyWrapping: jsObject.catch!(closure).object!)
     }
 
-    #if compiler(>=5.5)
+    #if compiler(>=5.5) && (!hasFeature(Embedded) || os(WASI))
     /// Schedules the `failure` closure to be invoked on rejected completion of `self`.
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     @discardableResult

--- a/Sources/JavaScriptKit/BasicObjects/JSPromise.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSPromise.swift
@@ -84,10 +84,9 @@ public final class JSPromise: JSBridgedClass {
     }
     #endif
 
-    #if !hasFeature(Embedded)
     /// Schedules the `success` closure to be invoked on successful completion of `self`.
     @discardableResult
-    public func then(success: @escaping (JSValue) -> ConvertibleToJSValue) -> JSPromise {
+    public func then(success: @escaping (JSValue) -> some ConvertibleToJSValue) -> JSPromise {
         let closure = JSOneshotClosure {
             success($0[0]).jsValue
         }
@@ -98,7 +97,7 @@ public final class JSPromise: JSBridgedClass {
     /// Schedules the `success` closure to be invoked on successful completion of `self`.
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     @discardableResult
-    public func then(success: sending @escaping (sending JSValue) async throws -> ConvertibleToJSValue) -> JSPromise {
+    public func then(success: sending @escaping (sending JSValue) async throws -> some ConvertibleToJSValue) -> JSPromise {
         let closure = JSOneshotClosure.async {
             try await success($0[0]).jsValue
         }
@@ -109,8 +108,8 @@ public final class JSPromise: JSBridgedClass {
     /// Schedules the `success` closure to be invoked on successful completion of `self`.
     @discardableResult
     public func then(
-        success: @escaping (sending JSValue) -> ConvertibleToJSValue,
-        failure: @escaping (sending JSValue) -> ConvertibleToJSValue
+        success: @escaping (sending JSValue) -> some ConvertibleToJSValue,
+        failure: @escaping (sending JSValue) -> some ConvertibleToJSValue
     ) -> JSPromise {
         let successClosure = JSOneshotClosure {
             success($0[0]).jsValue
@@ -126,8 +125,8 @@ public final class JSPromise: JSBridgedClass {
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     @discardableResult
     public func then(
-        success: sending @escaping (sending JSValue) async throws -> ConvertibleToJSValue,
-        failure: sending @escaping (sending JSValue) async throws -> ConvertibleToJSValue
+        success: sending @escaping (sending JSValue) async throws -> some ConvertibleToJSValue,
+        failure: sending @escaping (sending JSValue) async throws -> some ConvertibleToJSValue
     ) -> JSPromise {
         let successClosure = JSOneshotClosure.async {
             try await success($0[0]).jsValue
@@ -141,7 +140,9 @@ public final class JSPromise: JSBridgedClass {
 
     /// Schedules the `failure` closure to be invoked on rejected completion of `self`.
     @discardableResult
-    public func `catch`(failure: @escaping (sending JSValue) -> ConvertibleToJSValue) -> JSPromise {
+    public func `catch`(failure: @escaping (sending JSValue) -> some ConvertibleToJSValue)
+        -> JSPromise
+    {
         let closure = JSOneshotClosure {
             failure($0[0]).jsValue
         }
@@ -152,7 +153,7 @@ public final class JSPromise: JSBridgedClass {
     /// Schedules the `failure` closure to be invoked on rejected completion of `self`.
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     @discardableResult
-    public func `catch`(failure: sending @escaping (sending JSValue) async throws -> ConvertibleToJSValue) -> JSPromise
+    public func `catch`(failure: sending @escaping (sending JSValue) async throws -> some ConvertibleToJSValue) -> JSPromise
     {
         let closure = JSOneshotClosure.async {
             try await failure($0[0]).jsValue
@@ -171,5 +172,4 @@ public final class JSPromise: JSBridgedClass {
         }
         return .init(unsafelyWrapping: jsObject.finally!(closure).object!)
     }
-    #endif
 }

--- a/Sources/JavaScriptKit/BasicObjects/JSPromise.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSPromise.swift
@@ -86,7 +86,7 @@ public final class JSPromise: JSBridgedClass {
 
     /// Schedules the `success` closure to be invoked on successful completion of `self`.
     @discardableResult
-    public func then(success: @escaping (JSValue) -> some ConvertibleToJSValue) -> JSPromise {
+    public func then(success: @escaping (JSValue) -> JSValue) -> JSPromise {
         let closure = JSOneshotClosure {
             success($0[0]).jsValue
         }
@@ -98,7 +98,7 @@ public final class JSPromise: JSBridgedClass {
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     @discardableResult
     public func then(
-        success: sending @escaping (sending JSValue) async throws -> some ConvertibleToJSValue
+        success: sending @escaping (sending JSValue) async throws -> JSValue
     ) -> JSPromise {
         let closure = JSOneshotClosure.async {
             try await success($0[0]).jsValue
@@ -110,8 +110,8 @@ public final class JSPromise: JSBridgedClass {
     /// Schedules the `success` closure to be invoked on successful completion of `self`.
     @discardableResult
     public func then(
-        success: @escaping (sending JSValue) -> some ConvertibleToJSValue,
-        failure: @escaping (sending JSValue) -> some ConvertibleToJSValue
+        success: @escaping (sending JSValue) -> JSValue,
+        failure: @escaping (sending JSValue) -> JSValue
     ) -> JSPromise {
         let successClosure = JSOneshotClosure {
             success($0[0]).jsValue
@@ -127,8 +127,8 @@ public final class JSPromise: JSBridgedClass {
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     @discardableResult
     public func then(
-        success: sending @escaping (sending JSValue) async throws -> some ConvertibleToJSValue,
-        failure: sending @escaping (sending JSValue) async throws -> some ConvertibleToJSValue
+        success: sending @escaping (sending JSValue) async throws -> JSValue,
+        failure: sending @escaping (sending JSValue) async throws -> JSValue
     ) -> JSPromise {
         let successClosure = JSOneshotClosure.async {
             try await success($0[0]).jsValue
@@ -143,7 +143,7 @@ public final class JSPromise: JSBridgedClass {
     /// Schedules the `failure` closure to be invoked on rejected completion of `self`.
     @discardableResult
     public func `catch`(
-        failure: @escaping (sending JSValue) -> some ConvertibleToJSValue
+        failure: @escaping (sending JSValue) -> JSValue
     )
         -> JSPromise
     {
@@ -158,7 +158,7 @@ public final class JSPromise: JSBridgedClass {
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     @discardableResult
     public func `catch`(
-        failure: sending @escaping (sending JSValue) async throws -> some ConvertibleToJSValue
+        failure: sending @escaping (sending JSValue) async throws -> JSValue
     ) -> JSPromise {
         let closure = JSOneshotClosure.async {
             try await failure($0[0]).jsValue

--- a/Sources/JavaScriptKit/BasicObjects/JSPromise.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSPromise.swift
@@ -97,7 +97,9 @@ public final class JSPromise: JSBridgedClass {
     /// Schedules the `success` closure to be invoked on successful completion of `self`.
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     @discardableResult
-    public func then(success: sending @escaping (sending JSValue) async throws -> some ConvertibleToJSValue) -> JSPromise {
+    public func then(
+        success: sending @escaping (sending JSValue) async throws -> some ConvertibleToJSValue
+    ) -> JSPromise {
         let closure = JSOneshotClosure.async {
             try await success($0[0]).jsValue
         }
@@ -140,7 +142,9 @@ public final class JSPromise: JSBridgedClass {
 
     /// Schedules the `failure` closure to be invoked on rejected completion of `self`.
     @discardableResult
-    public func `catch`(failure: @escaping (sending JSValue) -> some ConvertibleToJSValue)
+    public func `catch`(
+        failure: @escaping (sending JSValue) -> some ConvertibleToJSValue
+    )
         -> JSPromise
     {
         let closure = JSOneshotClosure {
@@ -153,8 +157,9 @@ public final class JSPromise: JSBridgedClass {
     /// Schedules the `failure` closure to be invoked on rejected completion of `self`.
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     @discardableResult
-    public func `catch`(failure: sending @escaping (sending JSValue) async throws -> some ConvertibleToJSValue) -> JSPromise
-    {
+    public func `catch`(
+        failure: sending @escaping (sending JSValue) async throws -> some ConvertibleToJSValue
+    ) -> JSPromise {
         let closure = JSOneshotClosure.async {
             try await failure($0[0]).jsValue
         }

--- a/Sources/JavaScriptKit/FundamentalObjects/JSClosure.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSClosure.swift
@@ -1,5 +1,7 @@
 import _CJavaScriptKit
+#if hasFeature(Embedded) && os(WASI)
 import _Concurrency
+#endif
 
 /// `JSClosureProtocol` wraps Swift closure objects for use in JavaScript. Conforming types
 /// are responsible for managing the lifetime of the closure they wrap, but can delegate that
@@ -41,7 +43,7 @@ public class JSOneshotClosure: JSObject, JSClosureProtocol {
         fatalError("JSOneshotClosure does not support dictionary literal initialization")
     }
 
-    #if compiler(>=5.5)
+    #if compiler(>=5.5) && (!hasFeature(Embedded) || os(WASI))
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     public static func async(_ body: sending @escaping (sending [JSValue]) async throws -> JSValue) -> JSOneshotClosure
     {
@@ -133,7 +135,7 @@ public class JSClosure: JSFunction, JSClosureProtocol {
         fatalError("JSClosure does not support dictionary literal initialization")
     }
 
-    #if compiler(>=5.5) && !hasFeature(Embedded)
+    #if compiler(>=5.5) && (!hasFeature(Embedded) || os(WASI))
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     public static func async(_ body: @Sendable @escaping (sending [JSValue]) async throws -> JSValue) -> JSClosure {
         JSClosure(makeAsyncClosure(body))
@@ -149,7 +151,7 @@ public class JSClosure: JSFunction, JSClosureProtocol {
     #endif
 }
 
-#if compiler(>=5.5) && !hasFeature(Embedded)
+#if compiler(>=5.5) && (!hasFeature(Embedded) || os(WASI))
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 private func makeAsyncClosure(
     _ body: sending @escaping (sending [JSValue]) async throws -> JSValue

--- a/Sources/JavaScriptKit/FundamentalObjects/JSClosure.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSClosure.swift
@@ -1,4 +1,5 @@
 import _CJavaScriptKit
+import _Concurrency
 
 /// `JSClosureProtocol` wraps Swift closure objects for use in JavaScript. Conforming types
 /// are responsible for managing the lifetime of the closure they wrap, but can delegate that
@@ -40,7 +41,7 @@ public class JSOneshotClosure: JSObject, JSClosureProtocol {
         fatalError("JSOneshotClosure does not support dictionary literal initialization")
     }
 
-    #if compiler(>=5.5) && !hasFeature(Embedded)
+    #if compiler(>=5.5)
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     public static func async(_ body: sending @escaping (sending [JSValue]) async throws -> JSValue) -> JSOneshotClosure
     {

--- a/Tests/JavaScriptEventLoopTests/JSPromiseTests.swift
+++ b/Tests/JavaScriptEventLoopTests/JSPromiseTests.swift
@@ -9,14 +9,14 @@ final class JSPromiseTests: XCTestCase {
             p1 = p1.then { value in
                 XCTAssertEqual(value, .null)
                 continuation.resume()
-                return JSValue.number(1.0)
+                return JSValue.number(1.0).jsValue
             }
         }
         await withCheckedContinuation { continuation in
             p1 = p1.then { value in
                 XCTAssertEqual(value, .number(1.0))
                 continuation.resume()
-                return JSPromise.resolve(JSValue.boolean(true))
+                return JSPromise.resolve(JSValue.boolean(true)).jsValue
             }
         }
         await withCheckedContinuation { continuation in
@@ -48,7 +48,7 @@ final class JSPromiseTests: XCTestCase {
             p2 = p2.then { value in
                 XCTAssertEqual(value, .boolean(true))
                 continuation.resume()
-                return JSPromise.reject(JSValue.number(2.0))
+                return JSPromise.reject(JSValue.number(2.0)).jsValue
             }
         }
         await withCheckedContinuation { continuation in

--- a/Tests/JavaScriptEventLoopTests/JavaScriptEventLoopTests.swift
+++ b/Tests/JavaScriptEventLoopTests/JavaScriptEventLoopTests.swift
@@ -171,7 +171,7 @@ final class JavaScriptEventLoopTests: XCTestCase {
                 100
             )
         }
-        let failingPromise2 = failingPromise.then { _ in
+        let failingPromise2 = failingPromise.then { _ -> JSValue in
             throw MessageError("Should not be called", file: #file, line: #line, column: #column)
         } failure: { err in
             return err

--- a/Tests/JavaScriptEventLoopTests/JavaScriptEventLoopTests.swift
+++ b/Tests/JavaScriptEventLoopTests/JavaScriptEventLoopTests.swift
@@ -151,7 +151,7 @@ final class JavaScriptEventLoopTests: XCTestCase {
         }
         let promise2 = promise.then { result in
             try await Task.sleep(nanoseconds: 100_000_000)
-            return String(result.number!)
+            return .string(String(result.number!))
         }
         let thenDiff = try await measureTime {
             let result = try await promise2.value


### PR DESCRIPTION
The change fixes some issues in the JavaScriptKit library when build with Embedded Swift support. Specifically, `@MainActor` type is not available in Embedded Swift, thus `Atomic` type is used instead. Similarly, existential types are not available either, so they're replaced with concrete `some` types and generics.