### PR TITLE
Restricting throwable exception type to JSException for closures

### DIFF
--- a/Sources/JavaScriptEventLoop/JavaScriptEventLoop+ExecutorFactory.swift
+++ b/Sources/JavaScriptEventLoop/JavaScriptEventLoop+ExecutorFactory.swift
@@ -4,6 +4,7 @@
 // See: https://github.com/swiftlang/swift/pull/80266
 // See: https://forums.swift.org/t/pitch-2-custom-main-and-global-executors/78437
 
+import _Concurrency
 import _CJavaScriptKit
 
 #if compiler(>=6.2)

--- a/Sources/JavaScriptEventLoop/JavaScriptEventLoop+LegacyHooks.swift
+++ b/Sources/JavaScriptEventLoop/JavaScriptEventLoop+LegacyHooks.swift
@@ -1,3 +1,4 @@
+import _Concurrency
 import _CJavaScriptEventLoop
 import _CJavaScriptKit
 

--- a/Sources/JavaScriptKit/BasicObjects/JSPromise.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSPromise.swift
@@ -98,10 +98,10 @@ public final class JSPromise: JSBridgedClass {
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     @discardableResult
     public func then(
-        success: sending @escaping (sending JSValue) async throws -> JSValue
+        success: sending @escaping (sending JSValue) async throws(JSException) -> JSValue
     ) -> JSPromise {
-        let closure = JSOneshotClosure.async {
-            try await success($0[0]).jsValue
+        let closure = JSOneshotClosure.async { arguments throws(JSException) -> JSValue in
+            return try await success(arguments[0])
         }
         return JSPromise(unsafelyWrapping: jsObject.then!(closure).object!)
     }
@@ -127,14 +127,14 @@ public final class JSPromise: JSBridgedClass {
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     @discardableResult
     public func then(
-        success: sending @escaping (sending JSValue) async throws -> JSValue,
-        failure: sending @escaping (sending JSValue) async throws -> JSValue
+        success: sending @escaping (sending JSValue) async throws(JSException) -> JSValue,
+        failure: sending @escaping (sending JSValue) async throws(JSException) -> JSValue
     ) -> JSPromise {
-        let successClosure = JSOneshotClosure.async {
-            try await success($0[0]).jsValue
+        let successClosure = JSOneshotClosure.async { arguments throws(JSException) -> JSValue in
+            try await success(arguments[0]).jsValue
         }
-        let failureClosure = JSOneshotClosure.async {
-            try await failure($0[0]).jsValue
+        let failureClosure = JSOneshotClosure.async { arguments throws(JSException) -> JSValue in
+            try await failure(arguments[0]).jsValue
         }
         return JSPromise(unsafelyWrapping: jsObject.then!(successClosure, failureClosure).object!)
     }
@@ -158,10 +158,10 @@ public final class JSPromise: JSBridgedClass {
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     @discardableResult
     public func `catch`(
-        failure: sending @escaping (sending JSValue) async throws -> JSValue
+        failure: sending @escaping (sending JSValue) async throws(JSException) -> JSValue
     ) -> JSPromise {
-        let closure = JSOneshotClosure.async {
-            try await failure($0[0]).jsValue
+        let closure = JSOneshotClosure.async { arguments throws(JSException) -> JSValue in
+            try await failure(arguments[0]).jsValue
         }
         return .init(unsafelyWrapping: jsObject.catch!(closure).object!)
     }

--- a/Sources/JavaScriptKit/FundamentalObjects/JSClosure.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSClosure.swift
@@ -45,8 +45,9 @@ public class JSOneshotClosure: JSObject, JSClosureProtocol {
 
     #if compiler(>=5.5) && (!hasFeature(Embedded) || os(WASI))
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-    public static func async(_ body: sending @escaping (sending [JSValue]) async throws -> JSValue) -> JSOneshotClosure
-    {
+    public static func async(
+        _ body: sending @escaping (sending [JSValue]) async throws(JSException) -> JSValue
+    ) -> JSOneshotClosure {
         JSOneshotClosure(makeAsyncClosure(body))
     }
     #endif
@@ -137,7 +138,9 @@ public class JSClosure: JSFunction, JSClosureProtocol {
 
     #if compiler(>=5.5) && (!hasFeature(Embedded) || os(WASI))
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-    public static func async(_ body: @Sendable @escaping (sending [JSValue]) async throws -> JSValue) -> JSClosure {
+    public static func async(
+        _ body: @Sendable @escaping (sending [JSValue]) async throws(JSException) -> JSValue
+    ) -> JSClosure {
         JSClosure(makeAsyncClosure(body))
     }
     #endif
@@ -154,7 +157,7 @@ public class JSClosure: JSFunction, JSClosureProtocol {
 #if compiler(>=5.5) && (!hasFeature(Embedded) || os(WASI))
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 private func makeAsyncClosure(
-    _ body: sending @escaping (sending [JSValue]) async throws -> JSValue
+    _ body: sending @escaping (sending [JSValue]) async throws(JSException) -> JSValue
 ) -> ((sending [JSValue]) -> JSValue) {
     { arguments in
         JSPromise { resolver in

--- a/Tests/JavaScriptEventLoopTests/JavaScriptEventLoopTests.swift
+++ b/Tests/JavaScriptEventLoopTests/JavaScriptEventLoopTests.swift
@@ -150,7 +150,7 @@ final class JavaScriptEventLoopTests: XCTestCase {
             )
         }
         let promise2 = promise.then { result in
-            try await Task.sleep(nanoseconds: 100_000_000)
+            try! await Task.sleep(nanoseconds: 100_000_000)
             return .string(String(result.number!))
         }
         let thenDiff = try await measureTime {
@@ -172,7 +172,7 @@ final class JavaScriptEventLoopTests: XCTestCase {
             )
         }
         let failingPromise2 = failingPromise.then { _ -> JSValue in
-            throw MessageError("Should not be called", file: #file, line: #line, column: #column)
+            fatalError("Should not be called")
         } failure: { err in
             return err
         }
@@ -192,7 +192,7 @@ final class JavaScriptEventLoopTests: XCTestCase {
             )
         }
         let catchPromise2 = catchPromise.catch { err in
-            try await Task.sleep(nanoseconds: 100_000_000)
+            try! await Task.sleep(nanoseconds: 100_000_000)
             return err
         }
         let catchDiff = try await measureTime {
@@ -225,7 +225,7 @@ final class JavaScriptEventLoopTests: XCTestCase {
     func testAsyncJSClosure() async throws {
         // Test Async JSClosure
         let delayClosure = JSClosure.async { _ -> JSValue in
-            try await Task.sleep(nanoseconds: 200_000_000)
+            try! await Task.sleep(nanoseconds: 200_000_000)
             return JSValue.number(3)
         }
         let delayObject = JSObject.global.Object.function!.new()


### PR DESCRIPTION
For embedded targets, we can't use `any Error`.