### PR TITLE
BridgeJS: Gate @_extern/@expose usage behind `arch(wasm32)`

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSTool/ExportSwift.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSTool/ExportSwift.swift
@@ -272,6 +272,7 @@ class ExportSwift {
 
         @_spi(JSObject_id) import JavaScriptKit
 
+        #if arch(wasm32)
         @_extern(wasm, module: "bjs", name: "return_string")
         private func _return_string(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
         @_extern(wasm, module: "bjs", name: "init_memory")
@@ -281,6 +282,7 @@ class ExportSwift {
         private func _swift_js_retain(_ ptr: Int32) -> Int32
         @_extern(wasm, module: "bjs", name: "swift_js_throw")
         private func _swift_js_throw(_ id: Int32)
+        #endif
         """
 
     func renderSwiftGlue() -> String? {
@@ -512,7 +514,11 @@ class ExportSwift {
                 @_expose(wasm, "\(raw: abiName)")
                 @_cdecl("\(raw: abiName)")
                 public func _\(raw: abiName)(\(raw: parameterSignature())) -> \(raw: returnSignature()) {
+                    #if arch(wasm32)
                 \(body)
+                    #else
+                    fatalError("Only available on WebAssembly")
+                    #endif
                 }
                 """
         }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/PrimitiveParameters.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/PrimitiveParameters.swift
@@ -6,6 +6,7 @@
 
 @_spi(JSObject_id) import JavaScriptKit
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "return_string")
 private func _return_string(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
 @_extern(wasm, module: "bjs", name: "init_memory")
@@ -15,9 +16,14 @@ private func _init_memory(_ sourceId: Int32, _ ptr: UnsafeMutablePointer<UInt8>?
 private func _swift_js_retain(_ ptr: Int32) -> Int32
 @_extern(wasm, module: "bjs", name: "swift_js_throw")
 private func _swift_js_throw(_ id: Int32)
+#endif
 
 @_expose(wasm, "bjs_check")
 @_cdecl("bjs_check")
 public func _bjs_check(a: Int32, b: Float32, c: Float64, d: Int32) -> Void {
+    #if arch(wasm32)
     check(a: Int(a), b: b, c: c, d: d == 1)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/PrimitiveReturn.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/PrimitiveReturn.swift
@@ -6,6 +6,7 @@
 
 @_spi(JSObject_id) import JavaScriptKit
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "return_string")
 private func _return_string(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
 @_extern(wasm, module: "bjs", name: "init_memory")
@@ -15,31 +16,48 @@ private func _init_memory(_ sourceId: Int32, _ ptr: UnsafeMutablePointer<UInt8>?
 private func _swift_js_retain(_ ptr: Int32) -> Int32
 @_extern(wasm, module: "bjs", name: "swift_js_throw")
 private func _swift_js_throw(_ id: Int32)
+#endif
 
 @_expose(wasm, "bjs_checkInt")
 @_cdecl("bjs_checkInt")
 public func _bjs_checkInt() -> Int32 {
+    #if arch(wasm32)
     let ret = checkInt()
     return Int32(ret)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_checkFloat")
 @_cdecl("bjs_checkFloat")
 public func _bjs_checkFloat() -> Float32 {
+    #if arch(wasm32)
     let ret = checkFloat()
     return Float32(ret)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_checkDouble")
 @_cdecl("bjs_checkDouble")
 public func _bjs_checkDouble() -> Float64 {
+    #if arch(wasm32)
     let ret = checkDouble()
     return Float64(ret)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_checkBool")
 @_cdecl("bjs_checkBool")
 public func _bjs_checkBool() -> Int32 {
+    #if arch(wasm32)
     let ret = checkBool()
     return Int32(ret ? 1 : 0)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StringParameter.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StringParameter.swift
@@ -6,6 +6,7 @@
 
 @_spi(JSObject_id) import JavaScriptKit
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "return_string")
 private func _return_string(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
 @_extern(wasm, module: "bjs", name: "init_memory")
@@ -15,13 +16,18 @@ private func _init_memory(_ sourceId: Int32, _ ptr: UnsafeMutablePointer<UInt8>?
 private func _swift_js_retain(_ ptr: Int32) -> Int32
 @_extern(wasm, module: "bjs", name: "swift_js_throw")
 private func _swift_js_throw(_ id: Int32)
+#endif
 
 @_expose(wasm, "bjs_checkString")
 @_cdecl("bjs_checkString")
 public func _bjs_checkString(aBytes: Int32, aLen: Int32) -> Void {
+    #if arch(wasm32)
     let a = String(unsafeUninitializedCapacity: Int(aLen)) { b in
         _init_memory(aBytes, b.baseAddress.unsafelyUnwrapped)
         return Int(aLen)
     }
     checkString(a: a)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StringReturn.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StringReturn.swift
@@ -6,6 +6,7 @@
 
 @_spi(JSObject_id) import JavaScriptKit
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "return_string")
 private func _return_string(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
 @_extern(wasm, module: "bjs", name: "init_memory")
@@ -15,12 +16,17 @@ private func _init_memory(_ sourceId: Int32, _ ptr: UnsafeMutablePointer<UInt8>?
 private func _swift_js_retain(_ ptr: Int32) -> Int32
 @_extern(wasm, module: "bjs", name: "swift_js_throw")
 private func _swift_js_throw(_ id: Int32)
+#endif
 
 @_expose(wasm, "bjs_checkString")
 @_cdecl("bjs_checkString")
 public func _bjs_checkString() -> Void {
+    #if arch(wasm32)
     var ret = checkString()
     return ret.withUTF8 { ptr in
         _return_string(ptr.baseAddress, Int32(ptr.count))
     }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/SwiftClass.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/SwiftClass.swift
@@ -6,6 +6,7 @@
 
 @_spi(JSObject_id) import JavaScriptKit
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "return_string")
 private func _return_string(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
 @_extern(wasm, module: "bjs", name: "init_memory")
@@ -15,41 +16,58 @@ private func _init_memory(_ sourceId: Int32, _ ptr: UnsafeMutablePointer<UInt8>?
 private func _swift_js_retain(_ ptr: Int32) -> Int32
 @_extern(wasm, module: "bjs", name: "swift_js_throw")
 private func _swift_js_throw(_ id: Int32)
+#endif
 
 @_expose(wasm, "bjs_takeGreeter")
 @_cdecl("bjs_takeGreeter")
 public func _bjs_takeGreeter(greeter: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
     takeGreeter(greeter: Unmanaged<Greeter>.fromOpaque(greeter).takeUnretainedValue())
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_Greeter_init")
 @_cdecl("bjs_Greeter_init")
 public func _bjs_Greeter_init(nameBytes: Int32, nameLen: Int32) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
     let name = String(unsafeUninitializedCapacity: Int(nameLen)) { b in
         _init_memory(nameBytes, b.baseAddress.unsafelyUnwrapped)
         return Int(nameLen)
     }
     let ret = Greeter(name: name)
     return Unmanaged.passRetained(ret).toOpaque()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_Greeter_greet")
 @_cdecl("bjs_Greeter_greet")
 public func _bjs_Greeter_greet(_self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
     var ret = Unmanaged<Greeter>.fromOpaque(_self).takeUnretainedValue().greet()
     return ret.withUTF8 { ptr in
         _return_string(ptr.baseAddress, Int32(ptr.count))
     }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_Greeter_changeName")
 @_cdecl("bjs_Greeter_changeName")
 public func _bjs_Greeter_changeName(_self: UnsafeMutableRawPointer, nameBytes: Int32, nameLen: Int32) -> Void {
+    #if arch(wasm32)
     let name = String(unsafeUninitializedCapacity: Int(nameLen)) { b in
         _init_memory(nameBytes, b.baseAddress.unsafelyUnwrapped)
         return Int(nameLen)
     }
     Unmanaged<Greeter>.fromOpaque(_self).takeUnretainedValue().changeName(name: name)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_Greeter_deinit")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Throws.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Throws.swift
@@ -6,6 +6,7 @@
 
 @_spi(JSObject_id) import JavaScriptKit
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "return_string")
 private func _return_string(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
 @_extern(wasm, module: "bjs", name: "init_memory")
@@ -15,10 +16,12 @@ private func _init_memory(_ sourceId: Int32, _ ptr: UnsafeMutablePointer<UInt8>?
 private func _swift_js_retain(_ ptr: Int32) -> Int32
 @_extern(wasm, module: "bjs", name: "swift_js_throw")
 private func _swift_js_throw(_ id: Int32)
+#endif
 
 @_expose(wasm, "bjs_throwsSomething")
 @_cdecl("bjs_throwsSomething")
 public func _bjs_throwsSomething() -> Void {
+    #if arch(wasm32)
     do {
         try throwsSomething()
     } catch let error {
@@ -34,4 +37,7 @@ public func _bjs_throwsSomething() -> Void {
         }
         return
     }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/VoidParameterVoidReturn.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/VoidParameterVoidReturn.swift
@@ -6,6 +6,7 @@
 
 @_spi(JSObject_id) import JavaScriptKit
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "return_string")
 private func _return_string(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
 @_extern(wasm, module: "bjs", name: "init_memory")
@@ -15,9 +16,14 @@ private func _init_memory(_ sourceId: Int32, _ ptr: UnsafeMutablePointer<UInt8>?
 private func _swift_js_retain(_ ptr: Int32) -> Int32
 @_extern(wasm, module: "bjs", name: "swift_js_throw")
 private func _swift_js_throw(_ id: Int32)
+#endif
 
 @_expose(wasm, "bjs_check")
 @_cdecl("bjs_check")
 public func _bjs_check() -> Void {
+    #if arch(wasm32)
     check()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/ArrayParameter.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/ArrayParameter.swift
@@ -6,26 +6,56 @@
 
 @_spi(JSObject_id) import JavaScriptKit
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "make_jsstring")
-private func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32
+func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32
+#else
+func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "init_memory_with_result")
-private func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
+func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
+#else
+func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 func checkArray(_ a: JSObject) -> Void {
+    #if arch(wasm32)
     @_extern(wasm, module: "Check", name: "bjs_checkArray")
     func bjs_checkArray(_ a: Int32) -> Void
+    #else
+    func bjs_checkArray(_ a: Int32) -> Void {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
     bjs_checkArray(Int32(bitPattern: a.id))
 }
 
 func checkArrayWithLength(_ a: JSObject, _ b: Double) -> Void {
+    #if arch(wasm32)
     @_extern(wasm, module: "Check", name: "bjs_checkArrayWithLength")
     func bjs_checkArrayWithLength(_ a: Int32, _ b: Float64) -> Void
+    #else
+    func bjs_checkArrayWithLength(_ a: Int32, _ b: Float64) -> Void {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
     bjs_checkArrayWithLength(Int32(bitPattern: a.id), b)
 }
 
 func checkArray(_ a: JSObject) -> Void {
+    #if arch(wasm32)
     @_extern(wasm, module: "Check", name: "bjs_checkArray")
     func bjs_checkArray(_ a: Int32) -> Void
+    #else
+    func bjs_checkArray(_ a: Int32) -> Void {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
     bjs_checkArray(Int32(bitPattern: a.id))
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/Interface.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/Interface.swift
@@ -6,15 +6,33 @@
 
 @_spi(JSObject_id) import JavaScriptKit
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "make_jsstring")
-private func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32
+func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32
+#else
+func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "init_memory_with_result")
-private func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
+func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
+#else
+func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 func returnAnimatable() -> Animatable {
+    #if arch(wasm32)
     @_extern(wasm, module: "Check", name: "bjs_returnAnimatable")
     func bjs_returnAnimatable() -> Int32
+    #else
+    func bjs_returnAnimatable() -> Int32 {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
     let ret = bjs_returnAnimatable()
     return Animatable(takingThis: ret)
 }
@@ -31,15 +49,27 @@ struct Animatable {
     }
 
     func animate(_ keyframes: JSObject, _ options: JSObject) -> JSObject {
+        #if arch(wasm32)
         @_extern(wasm, module: "Check", name: "bjs_Animatable_animate")
         func bjs_Animatable_animate(_ self: Int32, _ keyframes: Int32, _ options: Int32) -> Int32
+        #else
+        func bjs_Animatable_animate(_ self: Int32, _ keyframes: Int32, _ options: Int32) -> Int32 {
+            fatalError("Only available on WebAssembly")
+        }
+        #endif
         let ret = bjs_Animatable_animate(Int32(bitPattern: self.this.id), Int32(bitPattern: keyframes.id), Int32(bitPattern: options.id))
         return JSObject(id: UInt32(bitPattern: ret))
     }
 
     func getAnimations(_ options: JSObject) -> JSObject {
+        #if arch(wasm32)
         @_extern(wasm, module: "Check", name: "bjs_Animatable_getAnimations")
         func bjs_Animatable_getAnimations(_ self: Int32, _ options: Int32) -> Int32
+        #else
+        func bjs_Animatable_getAnimations(_ self: Int32, _ options: Int32) -> Int32 {
+            fatalError("Only available on WebAssembly")
+        }
+        #endif
         let ret = bjs_Animatable_getAnimations(Int32(bitPattern: self.this.id), Int32(bitPattern: options.id))
         return JSObject(id: UInt32(bitPattern: ret))
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/PrimitiveParameters.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/PrimitiveParameters.swift
@@ -6,14 +6,32 @@
 
 @_spi(JSObject_id) import JavaScriptKit
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "make_jsstring")
-private func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32
+func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32
+#else
+func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "init_memory_with_result")
-private func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
+func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
+#else
+func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 func check(_ a: Double, _ b: Bool) -> Void {
+    #if arch(wasm32)
     @_extern(wasm, module: "Check", name: "bjs_check")
     func bjs_check(_ a: Float64, _ b: Int32) -> Void
+    #else
+    func bjs_check(_ a: Float64, _ b: Int32) -> Void {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
     bjs_check(a, Int32(b ? 1 : 0))
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/PrimitiveReturn.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/PrimitiveReturn.swift
@@ -6,22 +6,46 @@
 
 @_spi(JSObject_id) import JavaScriptKit
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "make_jsstring")
-private func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32
+func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32
+#else
+func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "init_memory_with_result")
-private func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
+func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
+#else
+func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 func checkNumber() -> Double {
+    #if arch(wasm32)
     @_extern(wasm, module: "Check", name: "bjs_checkNumber")
     func bjs_checkNumber() -> Float64
+    #else
+    func bjs_checkNumber() -> Float64 {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
     let ret = bjs_checkNumber()
     return Double(ret)
 }
 
 func checkBoolean() -> Bool {
+    #if arch(wasm32)
     @_extern(wasm, module: "Check", name: "bjs_checkBoolean")
     func bjs_checkBoolean() -> Int32
+    #else
+    func bjs_checkBoolean() -> Int32 {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
     let ret = bjs_checkBoolean()
     return ret == 1
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/StringParameter.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/StringParameter.swift
@@ -6,15 +6,33 @@
 
 @_spi(JSObject_id) import JavaScriptKit
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "make_jsstring")
-private func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32
+func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32
+#else
+func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "init_memory_with_result")
-private func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
+func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
+#else
+func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 func checkString(_ a: String) -> Void {
+    #if arch(wasm32)
     @_extern(wasm, module: "Check", name: "bjs_checkString")
     func bjs_checkString(_ a: Int32) -> Void
+    #else
+    func bjs_checkString(_ a: Int32) -> Void {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
     var a = a
     let aId = a.withUTF8 { b in
         _make_jsstring(b.baseAddress.unsafelyUnwrapped, Int32(b.count))
@@ -23,8 +41,14 @@ func checkString(_ a: String) -> Void {
 }
 
 func checkStringWithLength(_ a: String, _ b: Double) -> Void {
+    #if arch(wasm32)
     @_extern(wasm, module: "Check", name: "bjs_checkStringWithLength")
     func bjs_checkStringWithLength(_ a: Int32, _ b: Float64) -> Void
+    #else
+    func bjs_checkStringWithLength(_ a: Int32, _ b: Float64) -> Void {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
     var a = a
     let aId = a.withUTF8 { b in
         _make_jsstring(b.baseAddress.unsafelyUnwrapped, Int32(b.count))

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/StringReturn.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/StringReturn.swift
@@ -6,15 +6,33 @@
 
 @_spi(JSObject_id) import JavaScriptKit
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "make_jsstring")
-private func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32
+func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32
+#else
+func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "init_memory_with_result")
-private func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
+func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
+#else
+func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 func checkString() -> String {
+    #if arch(wasm32)
     @_extern(wasm, module: "Check", name: "bjs_checkString")
     func bjs_checkString() -> Int32
+    #else
+    func bjs_checkString() -> Int32 {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
     let ret = bjs_checkString()
     return String(unsafeUninitializedCapacity: Int(ret)) { b in
         _init_memory_with_result(b.baseAddress.unsafelyUnwrapped, Int32(ret))

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/TypeAlias.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/TypeAlias.swift
@@ -6,14 +6,32 @@
 
 @_spi(JSObject_id) import JavaScriptKit
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "make_jsstring")
-private func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32
+func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32
+#else
+func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "init_memory_with_result")
-private func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
+func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
+#else
+func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 func checkSimple(_ a: Double) -> Void {
+    #if arch(wasm32)
     @_extern(wasm, module: "Check", name: "bjs_checkSimple")
     func bjs_checkSimple(_ a: Float64) -> Void
+    #else
+    func bjs_checkSimple(_ a: Float64) -> Void {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
     bjs_checkSimple(a)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/TypeScriptClass.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/TypeScriptClass.swift
@@ -6,11 +6,23 @@
 
 @_spi(JSObject_id) import JavaScriptKit
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "make_jsstring")
-private func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32
+func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32
+#else
+func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "init_memory_with_result")
-private func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
+func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
+#else
+func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 struct Greeter {
     let this: JSObject
@@ -24,8 +36,14 @@ struct Greeter {
     }
 
     init(_ name: String) {
+        #if arch(wasm32)
         @_extern(wasm, module: "Check", name: "bjs_Greeter_init")
         func bjs_Greeter_init(_ name: Int32) -> Int32
+        #else
+        func bjs_Greeter_init(_ name: Int32) -> Int32 {
+            fatalError("Only available on WebAssembly")
+        }
+        #endif
         var name = name
         let nameId = name.withUTF8 { b in
             _make_jsstring(b.baseAddress.unsafelyUnwrapped, Int32(b.count))
@@ -36,8 +54,14 @@ struct Greeter {
 
     var name: String {
         get {
+            #if arch(wasm32)
             @_extern(wasm, module: "Check", name: "bjs_Greeter_name_get")
             func bjs_Greeter_name_get(_ self: Int32) -> Int32
+            #else
+            func bjs_Greeter_name_get(_ self: Int32) -> Int32 {
+                fatalError("Only available on WebAssembly")
+            }
+            #endif
             let ret = bjs_Greeter_name_get(Int32(bitPattern: self.this.id))
             return String(unsafeUninitializedCapacity: Int(ret)) { b in
                 _init_memory_with_result(b.baseAddress.unsafelyUnwrapped, Int32(ret))
@@ -45,8 +69,14 @@ struct Greeter {
             }
         }
         nonmutating set {
+            #if arch(wasm32)
             @_extern(wasm, module: "Check", name: "bjs_Greeter_name_set")
             func bjs_Greeter_name_set(_ self: Int32, _ newValue: Int32) -> Void
+            #else
+            func bjs_Greeter_name_set(_ self: Int32, _ newValue: Int32) -> Void {
+                fatalError("Only available on WebAssembly")
+            }
+            #endif
             var newValue = newValue
             let newValueId = newValue.withUTF8 { b in
                 _make_jsstring(b.baseAddress.unsafelyUnwrapped, Int32(b.count))
@@ -57,16 +87,28 @@ struct Greeter {
 
     var age: Double {
         get {
+            #if arch(wasm32)
             @_extern(wasm, module: "Check", name: "bjs_Greeter_age_get")
             func bjs_Greeter_age_get(_ self: Int32) -> Float64
+            #else
+            func bjs_Greeter_age_get(_ self: Int32) -> Float64 {
+                fatalError("Only available on WebAssembly")
+            }
+            #endif
             let ret = bjs_Greeter_age_get(Int32(bitPattern: self.this.id))
             return Double(ret)
         }
     }
 
     func greet() -> String {
+        #if arch(wasm32)
         @_extern(wasm, module: "Check", name: "bjs_Greeter_greet")
         func bjs_Greeter_greet(_ self: Int32) -> Int32
+        #else
+        func bjs_Greeter_greet(_ self: Int32) -> Int32 {
+            fatalError("Only available on WebAssembly")
+        }
+        #endif
         let ret = bjs_Greeter_greet(Int32(bitPattern: self.this.id))
         return String(unsafeUninitializedCapacity: Int(ret)) { b in
             _init_memory_with_result(b.baseAddress.unsafelyUnwrapped, Int32(ret))
@@ -75,8 +117,14 @@ struct Greeter {
     }
 
     func changeName(_ name: String) -> Void {
+        #if arch(wasm32)
         @_extern(wasm, module: "Check", name: "bjs_Greeter_changeName")
         func bjs_Greeter_changeName(_ self: Int32, _ name: Int32) -> Void
+        #else
+        func bjs_Greeter_changeName(_ self: Int32, _ name: Int32) -> Void {
+            fatalError("Only available on WebAssembly")
+        }
+        #endif
         var name = name
         let nameId = name.withUTF8 { b in
             _make_jsstring(b.baseAddress.unsafelyUnwrapped, Int32(b.count))

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/VoidParameterVoidReturn.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/VoidParameterVoidReturn.swift
@@ -6,14 +6,32 @@
 
 @_spi(JSObject_id) import JavaScriptKit
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "make_jsstring")
-private func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32
+func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32
+#else
+func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "init_memory_with_result")
-private func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
+func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
+#else
+func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 func check() -> Void {
+    #if arch(wasm32)
     @_extern(wasm, module: "Check", name: "bjs_check")
     func bjs_check() -> Void
+    #else
+    func bjs_check() -> Void {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
     bjs_check()
 }

--- a/Tests/BridgeJSRuntimeTests/Generated/ExportSwift.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/ExportSwift.swift
@@ -6,6 +6,7 @@
 
 @_spi(JSObject_id) import JavaScriptKit
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "return_string")
 private func _return_string(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
 @_extern(wasm, module: "bjs", name: "init_memory")
@@ -15,44 +16,66 @@ private func _init_memory(_ sourceId: Int32, _ ptr: UnsafeMutablePointer<UInt8>?
 private func _swift_js_retain(_ ptr: Int32) -> Int32
 @_extern(wasm, module: "bjs", name: "swift_js_throw")
 private func _swift_js_throw(_ id: Int32)
+#endif
 
 @_expose(wasm, "bjs_roundTripVoid")
 @_cdecl("bjs_roundTripVoid")
 public func _bjs_roundTripVoid() -> Void {
+    #if arch(wasm32)
     roundTripVoid()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_roundTripInt")
 @_cdecl("bjs_roundTripInt")
 public func _bjs_roundTripInt(v: Int32) -> Int32 {
+    #if arch(wasm32)
     let ret = roundTripInt(v: Int(v))
     return Int32(ret)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_roundTripFloat")
 @_cdecl("bjs_roundTripFloat")
 public func _bjs_roundTripFloat(v: Float32) -> Float32 {
+    #if arch(wasm32)
     let ret = roundTripFloat(v: v)
     return Float32(ret)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_roundTripDouble")
 @_cdecl("bjs_roundTripDouble")
 public func _bjs_roundTripDouble(v: Float64) -> Float64 {
+    #if arch(wasm32)
     let ret = roundTripDouble(v: v)
     return Float64(ret)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_roundTripBool")
 @_cdecl("bjs_roundTripBool")
 public func _bjs_roundTripBool(v: Int32) -> Int32 {
+    #if arch(wasm32)
     let ret = roundTripBool(v: v == 1)
     return Int32(ret ? 1 : 0)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_roundTripString")
 @_cdecl("bjs_roundTripString")
 public func _bjs_roundTripString(vBytes: Int32, vLen: Int32) -> Void {
+    #if arch(wasm32)
     let v = String(unsafeUninitializedCapacity: Int(vLen)) { b in
         _init_memory(vBytes, b.baseAddress.unsafelyUnwrapped)
         return Int(vLen)
@@ -61,25 +84,37 @@ public func _bjs_roundTripString(vBytes: Int32, vLen: Int32) -> Void {
     return ret.withUTF8 { ptr in
         _return_string(ptr.baseAddress, Int32(ptr.count))
     }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_roundTripSwiftHeapObject")
 @_cdecl("bjs_roundTripSwiftHeapObject")
 public func _bjs_roundTripSwiftHeapObject(v: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
     let ret = roundTripSwiftHeapObject(v: Unmanaged<Greeter>.fromOpaque(v).takeUnretainedValue())
     return Unmanaged.passRetained(ret).toOpaque()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_roundTripJSObject")
 @_cdecl("bjs_roundTripJSObject")
 public func _bjs_roundTripJSObject(v: Int32) -> Int32 {
+    #if arch(wasm32)
     let ret = roundTripJSObject(v: JSObject(id: UInt32(bitPattern: v)))
     return _swift_js_retain(Int32(bitPattern: ret.id))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_throwsSwiftError")
 @_cdecl("bjs_throwsSwiftError")
 public func _bjs_throwsSwiftError(shouldThrow: Int32) -> Void {
+    #if arch(wasm32)
     do {
         try throwsSwiftError(shouldThrow: shouldThrow == 1)
     } catch let error {
@@ -95,14 +130,18 @@ public func _bjs_throwsSwiftError(shouldThrow: Int32) -> Void {
         }
         return
     }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_throwsWithIntResult")
 @_cdecl("bjs_throwsWithIntResult")
 public func _bjs_throwsWithIntResult() -> Int32 {
+    #if arch(wasm32)
     do {
         let ret = try throwsWithIntResult()
-        return Int32(ret)
+    return Int32(ret)
     } catch let error {
         if let error = error.thrownValue.object {
             withExtendedLifetime(error) {
@@ -116,16 +155,20 @@ public func _bjs_throwsWithIntResult() -> Int32 {
         }
         return 0
     }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_throwsWithStringResult")
 @_cdecl("bjs_throwsWithStringResult")
 public func _bjs_throwsWithStringResult() -> Void {
+    #if arch(wasm32)
     do {
         var ret = try throwsWithStringResult()
-        return ret.withUTF8 { ptr in
-                _return_string(ptr.baseAddress, Int32(ptr.count))
-            }
+    return ret.withUTF8 { ptr in
+            _return_string(ptr.baseAddress, Int32(ptr.count))
+        }
     } catch let error {
         if let error = error.thrownValue.object {
             withExtendedLifetime(error) {
@@ -139,14 +182,18 @@ public func _bjs_throwsWithStringResult() -> Void {
         }
         return
     }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_throwsWithBoolResult")
 @_cdecl("bjs_throwsWithBoolResult")
 public func _bjs_throwsWithBoolResult() -> Int32 {
+    #if arch(wasm32)
     do {
         let ret = try throwsWithBoolResult()
-        return Int32(ret ? 1 : 0)
+    return Int32(ret ? 1 : 0)
     } catch let error {
         if let error = error.thrownValue.object {
             withExtendedLifetime(error) {
@@ -160,14 +207,18 @@ public func _bjs_throwsWithBoolResult() -> Int32 {
         }
         return 0
     }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_throwsWithFloatResult")
 @_cdecl("bjs_throwsWithFloatResult")
 public func _bjs_throwsWithFloatResult() -> Float32 {
+    #if arch(wasm32)
     do {
         let ret = try throwsWithFloatResult()
-        return Float32(ret)
+    return Float32(ret)
     } catch let error {
         if let error = error.thrownValue.object {
             withExtendedLifetime(error) {
@@ -181,14 +232,18 @@ public func _bjs_throwsWithFloatResult() -> Float32 {
         }
         return 0.0
     }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_throwsWithDoubleResult")
 @_cdecl("bjs_throwsWithDoubleResult")
 public func _bjs_throwsWithDoubleResult() -> Float64 {
+    #if arch(wasm32)
     do {
         let ret = try throwsWithDoubleResult()
-        return Float64(ret)
+    return Float64(ret)
     } catch let error {
         if let error = error.thrownValue.object {
             withExtendedLifetime(error) {
@@ -202,14 +257,18 @@ public func _bjs_throwsWithDoubleResult() -> Float64 {
         }
         return 0.0
     }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_throwsWithSwiftHeapObjectResult")
 @_cdecl("bjs_throwsWithSwiftHeapObjectResult")
 public func _bjs_throwsWithSwiftHeapObjectResult() -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
     do {
         let ret = try throwsWithSwiftHeapObjectResult()
-        return Unmanaged.passRetained(ret).toOpaque()
+    return Unmanaged.passRetained(ret).toOpaque()
     } catch let error {
         if let error = error.thrownValue.object {
             withExtendedLifetime(error) {
@@ -223,14 +282,18 @@ public func _bjs_throwsWithSwiftHeapObjectResult() -> UnsafeMutableRawPointer {
         }
         return UnsafeMutableRawPointer(bitPattern: -1).unsafelyUnwrapped
     }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_throwsWithJSObjectResult")
 @_cdecl("bjs_throwsWithJSObjectResult")
 public func _bjs_throwsWithJSObjectResult() -> Int32 {
+    #if arch(wasm32)
     do {
         let ret = try throwsWithJSObjectResult()
-        return _swift_js_retain(Int32(bitPattern: ret.id))
+    return _swift_js_retain(Int32(bitPattern: ret.id))
     } catch let error {
         if let error = error.thrownValue.object {
             withExtendedLifetime(error) {
@@ -244,46 +307,65 @@ public func _bjs_throwsWithJSObjectResult() -> Int32 {
         }
         return 0
     }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_takeGreeter")
 @_cdecl("bjs_takeGreeter")
 public func _bjs_takeGreeter(g: UnsafeMutableRawPointer, nameBytes: Int32, nameLen: Int32) -> Void {
+    #if arch(wasm32)
     let name = String(unsafeUninitializedCapacity: Int(nameLen)) { b in
         _init_memory(nameBytes, b.baseAddress.unsafelyUnwrapped)
         return Int(nameLen)
     }
     takeGreeter(g: Unmanaged<Greeter>.fromOpaque(g).takeUnretainedValue(), name: name)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_Greeter_init")
 @_cdecl("bjs_Greeter_init")
 public func _bjs_Greeter_init(nameBytes: Int32, nameLen: Int32) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
     let name = String(unsafeUninitializedCapacity: Int(nameLen)) { b in
         _init_memory(nameBytes, b.baseAddress.unsafelyUnwrapped)
         return Int(nameLen)
     }
     let ret = Greeter(name: name)
     return Unmanaged.passRetained(ret).toOpaque()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_Greeter_greet")
 @_cdecl("bjs_Greeter_greet")
 public func _bjs_Greeter_greet(_self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
     var ret = Unmanaged<Greeter>.fromOpaque(_self).takeUnretainedValue().greet()
     return ret.withUTF8 { ptr in
         _return_string(ptr.baseAddress, Int32(ptr.count))
     }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_Greeter_changeName")
 @_cdecl("bjs_Greeter_changeName")
 public func _bjs_Greeter_changeName(_self: UnsafeMutableRawPointer, nameBytes: Int32, nameLen: Int32) -> Void {
+    #if arch(wasm32)
     let name = String(unsafeUninitializedCapacity: Int(nameLen)) { b in
         _init_memory(nameBytes, b.baseAddress.unsafelyUnwrapped)
         return Int(nameLen)
     }
     Unmanaged<Greeter>.fromOpaque(_self).takeUnretainedValue().changeName(name: name)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_Greeter_deinit")

--- a/Tests/BridgeJSRuntimeTests/Generated/ImportTS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/ImportTS.swift
@@ -6,35 +6,71 @@
 
 @_spi(JSObject_id) import JavaScriptKit
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "make_jsstring")
-private func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32
+func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32
+#else
+func _make_jsstring(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "init_memory_with_result")
-private func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
+func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
+#else
+func _init_memory_with_result(_ ptr: UnsafePointer<UInt8>?, _ len: Int32) {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 func jsRoundTripVoid() -> Void {
+    #if arch(wasm32)
     @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripVoid")
     func bjs_jsRoundTripVoid() -> Void
+    #else
+    func bjs_jsRoundTripVoid() -> Void {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
     bjs_jsRoundTripVoid()
 }
 
 func jsRoundTripNumber(_ v: Double) -> Double {
+    #if arch(wasm32)
     @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripNumber")
     func bjs_jsRoundTripNumber(_ v: Float64) -> Float64
+    #else
+    func bjs_jsRoundTripNumber(_ v: Float64) -> Float64 {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
     let ret = bjs_jsRoundTripNumber(v)
     return Double(ret)
 }
 
 func jsRoundTripBool(_ v: Bool) -> Bool {
+    #if arch(wasm32)
     @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripBool")
     func bjs_jsRoundTripBool(_ v: Int32) -> Int32
+    #else
+    func bjs_jsRoundTripBool(_ v: Int32) -> Int32 {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
     let ret = bjs_jsRoundTripBool(Int32(v ? 1 : 0))
     return ret == 1
 }
 
 func jsRoundTripString(_ v: String) -> String {
+    #if arch(wasm32)
     @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripString")
     func bjs_jsRoundTripString(_ v: Int32) -> Int32
+    #else
+    func bjs_jsRoundTripString(_ v: Int32) -> Int32 {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
     var v = v
     let vId = v.withUTF8 { b in
         _make_jsstring(b.baseAddress.unsafelyUnwrapped, Int32(b.count))
@@ -58,8 +94,14 @@ struct JsGreeter {
     }
 
     init(_ name: String, _ prefix: String) {
+        #if arch(wasm32)
         @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_JsGreeter_init")
         func bjs_JsGreeter_init(_ name: Int32, _ prefix: Int32) -> Int32
+        #else
+        func bjs_JsGreeter_init(_ name: Int32, _ prefix: Int32) -> Int32 {
+            fatalError("Only available on WebAssembly")
+        }
+        #endif
         var name = name
         let nameId = name.withUTF8 { b in
             _make_jsstring(b.baseAddress.unsafelyUnwrapped, Int32(b.count))
@@ -74,8 +116,14 @@ struct JsGreeter {
 
     var name: String {
         get {
+            #if arch(wasm32)
             @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_JsGreeter_name_get")
             func bjs_JsGreeter_name_get(_ self: Int32) -> Int32
+            #else
+            func bjs_JsGreeter_name_get(_ self: Int32) -> Int32 {
+                fatalError("Only available on WebAssembly")
+            }
+            #endif
             let ret = bjs_JsGreeter_name_get(Int32(bitPattern: self.this.id))
             return String(unsafeUninitializedCapacity: Int(ret)) { b in
                 _init_memory_with_result(b.baseAddress.unsafelyUnwrapped, Int32(ret))
@@ -83,8 +131,14 @@ struct JsGreeter {
             }
         }
         nonmutating set {
+            #if arch(wasm32)
             @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_JsGreeter_name_set")
             func bjs_JsGreeter_name_set(_ self: Int32, _ newValue: Int32) -> Void
+            #else
+            func bjs_JsGreeter_name_set(_ self: Int32, _ newValue: Int32) -> Void {
+                fatalError("Only available on WebAssembly")
+            }
+            #endif
             var newValue = newValue
             let newValueId = newValue.withUTF8 { b in
                 _make_jsstring(b.baseAddress.unsafelyUnwrapped, Int32(b.count))
@@ -95,8 +149,14 @@ struct JsGreeter {
 
     var prefix: String {
         get {
+            #if arch(wasm32)
             @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_JsGreeter_prefix_get")
             func bjs_JsGreeter_prefix_get(_ self: Int32) -> Int32
+            #else
+            func bjs_JsGreeter_prefix_get(_ self: Int32) -> Int32 {
+                fatalError("Only available on WebAssembly")
+            }
+            #endif
             let ret = bjs_JsGreeter_prefix_get(Int32(bitPattern: self.this.id))
             return String(unsafeUninitializedCapacity: Int(ret)) { b in
                 _init_memory_with_result(b.baseAddress.unsafelyUnwrapped, Int32(ret))
@@ -106,8 +166,14 @@ struct JsGreeter {
     }
 
     func greet() -> String {
+        #if arch(wasm32)
         @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_JsGreeter_greet")
         func bjs_JsGreeter_greet(_ self: Int32) -> Int32
+        #else
+        func bjs_JsGreeter_greet(_ self: Int32) -> Int32 {
+            fatalError("Only available on WebAssembly")
+        }
+        #endif
         let ret = bjs_JsGreeter_greet(Int32(bitPattern: self.this.id))
         return String(unsafeUninitializedCapacity: Int(ret)) { b in
             _init_memory_with_result(b.baseAddress.unsafelyUnwrapped, Int32(ret))
@@ -116,8 +182,14 @@ struct JsGreeter {
     }
 
     func changeName(_ name: String) -> Void {
+        #if arch(wasm32)
         @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_JsGreeter_changeName")
         func bjs_JsGreeter_changeName(_ self: Int32, _ name: Int32) -> Void
+        #else
+        func bjs_JsGreeter_changeName(_ self: Int32, _ name: Int32) -> Void {
+            fatalError("Only available on WebAssembly")
+        }
+        #endif
         var name = name
         let nameId = name.withUTF8 { b in
             _make_jsstring(b.baseAddress.unsafelyUnwrapped, Int32(b.count))


### PR DESCRIPTION
Without gating them, we see linkage failures when developing on Xcode.