### PR TITLE
Slice a bytes array when the underlying memory is shared

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -4,6 +4,17 @@ struct BridgeJSLink {
     /// The exported skeletons
     var exportedSkeletons: [ExportedSkeleton] = []
     var importedSkeletons: [ImportedModuleSkeleton] = []
+    let sharedMemory: Bool
+
+    init(
+        exportedSkeletons: [ExportedSkeleton] = [],
+        importedSkeletons: [ImportedModuleSkeleton] = [],
+        sharedMemory: Bool
+    ) {
+        self.exportedSkeletons = exportedSkeletons
+        self.importedSkeletons = importedSkeletons
+        self.sharedMemory = sharedMemory
+    }
 
     mutating func addExportedSkeletonFile(data: Data) throws {
         let skeleton = try JSONDecoder().decode(ExportedSkeleton.self, from: data)
@@ -118,7 +129,7 @@ struct BridgeJSLink {
                         const bjs = {};
                         importObject["bjs"] = bjs;
                         bjs["return_string"] = function(ptr, len) {
-                            const bytes = new Uint8Array(memory.buffer, ptr, len);
+                            const bytes = new Uint8Array(memory.buffer, ptr, len)\(sharedMemory ? ".slice()" : "");
                             tmpRetString = textDecoder.decode(bytes);
                         }
                         bjs["init_memory"] = function(sourceId, bytesPtr) {
@@ -127,7 +138,7 @@ struct BridgeJSLink {
                             bytes.set(source);
                         }
                         bjs["make_jsstring"] = function(ptr, len) {
-                            const bytes = new Uint8Array(memory.buffer, ptr, len);
+                            const bytes = new Uint8Array(memory.buffer, ptr, len)\(sharedMemory ? ".slice()" : "");
                             return swift.memory.retain(textDecoder.decode(bytes));
                         }
                         bjs["init_memory_with_result"] = function(ptr, len) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/BridgeJSLinkTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/BridgeJSLinkTests.swift
@@ -55,7 +55,7 @@ import Testing
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let outputSkeletonData = try encoder.encode(outputSkeleton)
-        var bridgeJSLink = BridgeJSLink()
+        var bridgeJSLink = BridgeJSLink(sharedMemory: false)
         try bridgeJSLink.addExportedSkeletonFile(data: outputSkeletonData)
         try snapshot(bridgeJSLink: bridgeJSLink, name: name + ".Export")
     }
@@ -73,7 +73,7 @@ import Testing
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let outputSkeletonData = try encoder.encode(importTS.skeleton)
 
-        var bridgeJSLink = BridgeJSLink()
+        var bridgeJSLink = BridgeJSLink(sharedMemory: false)
         try bridgeJSLink.addImportedSkeletonFile(data: outputSkeletonData)
         try snapshot(bridgeJSLink: bridgeJSLink, name: name + ".Import")
     }


### PR DESCRIPTION
TextDecoder does not support decoding shared memory slices directly on browsers, so we need to slice the Uint8Array