### PR TITLE
BridgeJS: Async function support

### DIFF
--- a/Examples/ImportTS/index.js
+++ b/Examples/ImportTS/index.js
@@ -1,12 +1,14 @@
 import { init } from "./.build/plugins/PackageToJS/outputs/Package/index.js";
 const { exports } = await init({
-    imports: {
-        consoleLog: (message) => {
-            console.log(message);
-        },
-        getDocument: () => {
-            return document;
-        },
+    getImports() {
+        return {
+            consoleLog: (message) => {
+                console.log(message);
+            },
+            getDocument: () => {
+                return document;
+            },
+        }
     }
 });
 

--- a/Examples/PlayBridgeJS/Sources/JavaScript/app.js
+++ b/Examples/PlayBridgeJS/Sources/JavaScript/app.js
@@ -48,8 +48,10 @@ export class BridgeJSPlayground {
             // Import the BridgeJS module
             const { init } = await import("../../.build/plugins/PackageToJS/outputs/Package/index.js");
             const { exports } = await init({
-                imports: {
-                    createTS2Skeleton: this.createTS2Skeleton
+                getImports() {
+                    return {
+                        createTS2Skeleton: this.createTS2Skeleton
+                    }
                 }
             });
             this.playBridgeJS = new exports.PlayBridgeJS();

--- a/Package.swift
+++ b/Package.swift
@@ -155,7 +155,7 @@ let package = Package(
         ),
         .testTarget(
             name: "BridgeJSRuntimeTests",
-            dependencies: ["JavaScriptKit"],
+            dependencies: ["JavaScriptKit", "JavaScriptEventLoop"],
             exclude: [
                 "bridge-js.config.json",
                 "bridge-js.d.ts",

--- a/Plugins/BridgeJS/Sources/TS2Skeleton/JavaScript/src/index.d.ts
+++ b/Plugins/BridgeJS/Sources/TS2Skeleton/JavaScript/src/index.d.ts
@@ -12,10 +12,15 @@ export type Parameter = {
     type: BridgeType;
 }
 
+export type Effects = {
+    isAsync: boolean;
+}
+
 export type ImportFunctionSkeleton = {
     name: string;
     parameters: Parameter[];
     returnType: BridgeType;
+    effects: Effects;
     documentation: string | undefined;
 }
 

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/Async.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/Async.d.ts
@@ -1,0 +1,7 @@
+export function asyncReturnVoid(): Promise<void>;
+export function asyncRoundTripInt(v: number): Promise<number>;
+export function asyncRoundTripString(v: string): Promise<string>;
+export function asyncRoundTripBool(v: boolean): Promise<boolean>;
+export function asyncRoundTripFloat(v: number): Promise<number>;
+export function asyncRoundTripDouble(v: number): Promise<number>;
+export function asyncRoundTripJSObject(v: any): Promise<any>;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/Async.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/Async.swift
@@ -1,0 +1,19 @@
+@JS func asyncReturnVoid() async {}
+@JS func asyncRoundTripInt(_ v: Int) async -> Int {
+    return v
+}
+@JS func asyncRoundTripString(_ v: String) async -> String {
+    return v
+}
+@JS func asyncRoundTripBool(_ v: Bool) async -> Bool {
+    return v
+}
+@JS func asyncRoundTripFloat(_ v: Float) async -> Float {
+    return v
+}
+@JS func asyncRoundTripDouble(_ v: Double) async -> Double {
+    return v
+}
+@JS func asyncRoundTripJSObject(_ v: JSObject) async -> JSObject {
+    return v
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayParameter.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayParameter.Import.js
@@ -15,10 +15,13 @@ export async function createInstantiator(options, swift) {
     let tmpRetBytes;
     let tmpRetException;
     return {
-        /** @param {WebAssembly.Imports} importObject */
-        addImports: (importObject) => {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
             const bjs = {};
             importObject["bjs"] = bjs;
+            const imports = options.getImports(importsContext);
             bjs["swift_js_return_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
                 tmpRetString = textDecoder.decode(bytes);
@@ -50,21 +53,21 @@ export async function createInstantiator(options, swift) {
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_checkArray"] = function bjs_checkArray(a) {
                 try {
-                    options.imports.checkArray(swift.memory.getObject(a));
+                    imports.checkArray(swift.memory.getObject(a));
                 } catch (error) {
                     setException(error);
                 }
             }
             TestModule["bjs_checkArrayWithLength"] = function bjs_checkArrayWithLength(a, b) {
                 try {
-                    options.imports.checkArrayWithLength(swift.memory.getObject(a), b);
+                    imports.checkArrayWithLength(swift.memory.getObject(a), b);
                 } catch (error) {
                     setException(error);
                 }
             }
             TestModule["bjs_checkArray"] = function bjs_checkArray(a) {
                 try {
-                    options.imports.checkArray(swift.memory.getObject(a));
+                    imports.checkArray(swift.memory.getObject(a));
                 } catch (error) {
                     setException(error);
                 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.Export.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.Export.d.ts
@@ -1,0 +1,24 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export type Exports = {
+    asyncReturnVoid(): Promise<void>;
+    asyncRoundTripInt(v: number): Promise<number>;
+    asyncRoundTripString(v: string): Promise<string>;
+    asyncRoundTripBool(v: boolean): Promise<boolean>;
+    asyncRoundTripFloat(v: number): Promise<number>;
+    asyncRoundTripDouble(v: number): Promise<number>;
+    asyncRoundTripJSObject(v: any): Promise<any>;
+}
+export type Imports = {
+}
+export function createInstantiator(options: {
+    imports: Imports;
+}, swift: any): Promise<{
+    addImports: (importObject: WebAssembly.Imports) => void;
+    setInstance: (instance: WebAssembly.Instance) => void;
+    createExports: (instance: WebAssembly.Instance) => Exports;
+}>;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.Export.js
@@ -50,25 +50,7 @@ export async function createInstantiator(options, swift) {
                 swift.memory.release(id);
             }
 
-            const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
-            TestModule["bjs_checkString"] = function bjs_checkString(a) {
-                try {
-                    const aObject = swift.memory.getObject(a);
-                    swift.memory.release(a);
-                    imports.checkString(aObject);
-                } catch (error) {
-                    setException(error);
-                }
-            }
-            TestModule["bjs_checkStringWithLength"] = function bjs_checkStringWithLength(a, b) {
-                try {
-                    const aObject = swift.memory.getObject(a);
-                    swift.memory.release(a);
-                    imports.checkStringWithLength(aObject, b);
-                } catch (error) {
-                    setException(error);
-                }
-            }
+
         },
         setInstance: (i) => {
             instance = i;
@@ -82,7 +64,51 @@ export async function createInstantiator(options, swift) {
             const js = swift.memory.heap;
 
             return {
-
+                asyncReturnVoid: function bjs_asyncReturnVoid() {
+                    const retId = instance.exports.bjs_asyncReturnVoid();
+                    const ret = swift.memory.getObject(retId);
+                    swift.memory.release(retId);
+                    return ret;
+                },
+                asyncRoundTripInt: function bjs_asyncRoundTripInt(v) {
+                    const retId = instance.exports.bjs_asyncRoundTripInt(v);
+                    const ret = swift.memory.getObject(retId);
+                    swift.memory.release(retId);
+                    return ret;
+                },
+                asyncRoundTripString: function bjs_asyncRoundTripString(v) {
+                    const vBytes = textEncoder.encode(v);
+                    const vId = swift.memory.retain(vBytes);
+                    const retId = instance.exports.bjs_asyncRoundTripString(vId, vBytes.length);
+                    const ret = swift.memory.getObject(retId);
+                    swift.memory.release(retId);
+                    swift.memory.release(vId);
+                    return ret;
+                },
+                asyncRoundTripBool: function bjs_asyncRoundTripBool(v) {
+                    const retId = instance.exports.bjs_asyncRoundTripBool(v);
+                    const ret = swift.memory.getObject(retId);
+                    swift.memory.release(retId);
+                    return ret;
+                },
+                asyncRoundTripFloat: function bjs_asyncRoundTripFloat(v) {
+                    const retId = instance.exports.bjs_asyncRoundTripFloat(v);
+                    const ret = swift.memory.getObject(retId);
+                    swift.memory.release(retId);
+                    return ret;
+                },
+                asyncRoundTripDouble: function bjs_asyncRoundTripDouble(v) {
+                    const retId = instance.exports.bjs_asyncRoundTripDouble(v);
+                    const ret = swift.memory.getObject(retId);
+                    swift.memory.release(retId);
+                    return ret;
+                },
+                asyncRoundTripJSObject: function bjs_asyncRoundTripJSObject(v) {
+                    const retId = instance.exports.bjs_asyncRoundTripJSObject(swift.memory.retain(v));
+                    const ret = swift.memory.getObject(retId);
+                    swift.memory.release(retId);
+                    return ret;
+                },
             };
         },
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.Import.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.Import.d.ts
@@ -1,0 +1,24 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export type Exports = {
+}
+export type Imports = {
+    asyncReturnVoid(): JSPromise;
+    asyncRoundTripInt(v: number): JSPromise;
+    asyncRoundTripString(v: string): JSPromise;
+    asyncRoundTripBool(v: boolean): JSPromise;
+    asyncRoundTripFloat(v: number): JSPromise;
+    asyncRoundTripDouble(v: number): JSPromise;
+    asyncRoundTripJSObject(v: any): JSPromise;
+}
+export function createInstantiator(options: {
+    imports: Imports;
+}, swift: any): Promise<{
+    addImports: (importObject: WebAssembly.Imports) => void;
+    setInstance: (instance: WebAssembly.Instance) => void;
+    createExports: (instance: WebAssembly.Instance) => Exports;
+}>;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.Import.js
@@ -51,22 +51,69 @@ export async function createInstantiator(options, swift) {
             }
 
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
-            TestModule["bjs_checkString"] = function bjs_checkString(a) {
+            TestModule["bjs_asyncReturnVoid"] = function bjs_asyncReturnVoid() {
                 try {
-                    const aObject = swift.memory.getObject(a);
-                    swift.memory.release(a);
-                    imports.checkString(aObject);
+                    let ret = imports.asyncReturnVoid();
+                    return swift.memory.retain(ret);
                 } catch (error) {
                     setException(error);
+                    return 0
                 }
             }
-            TestModule["bjs_checkStringWithLength"] = function bjs_checkStringWithLength(a, b) {
+            TestModule["bjs_asyncRoundTripInt"] = function bjs_asyncRoundTripInt(v) {
                 try {
-                    const aObject = swift.memory.getObject(a);
-                    swift.memory.release(a);
-                    imports.checkStringWithLength(aObject, b);
+                    let ret = imports.asyncRoundTripInt(v);
+                    return swift.memory.retain(ret);
                 } catch (error) {
                     setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_asyncRoundTripString"] = function bjs_asyncRoundTripString(v) {
+                try {
+                    const vObject = swift.memory.getObject(v);
+                    swift.memory.release(v);
+                    let ret = imports.asyncRoundTripString(vObject);
+                    return swift.memory.retain(ret);
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_asyncRoundTripBool"] = function bjs_asyncRoundTripBool(v) {
+                try {
+                    let ret = imports.asyncRoundTripBool(v);
+                    return swift.memory.retain(ret);
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_asyncRoundTripFloat"] = function bjs_asyncRoundTripFloat(v) {
+                try {
+                    let ret = imports.asyncRoundTripFloat(v);
+                    return swift.memory.retain(ret);
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_asyncRoundTripDouble"] = function bjs_asyncRoundTripDouble(v) {
+                try {
+                    let ret = imports.asyncRoundTripDouble(v);
+                    return swift.memory.retain(ret);
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_asyncRoundTripJSObject"] = function bjs_asyncRoundTripJSObject(v) {
+                try {
+                    let ret = imports.asyncRoundTripJSObject(swift.memory.getObject(v));
+                    return swift.memory.retain(ret);
+                } catch (error) {
+                    setException(error);
+                    return 0
                 }
             }
         },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Interface.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Interface.Import.js
@@ -15,10 +15,13 @@ export async function createInstantiator(options, swift) {
     let tmpRetBytes;
     let tmpRetException;
     return {
-        /** @param {WebAssembly.Imports} importObject */
-        addImports: (importObject) => {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
             const bjs = {};
             importObject["bjs"] = bjs;
+            const imports = options.getImports(importsContext);
             bjs["swift_js_return_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
                 tmpRetString = textDecoder.decode(bytes);
@@ -50,7 +53,7 @@ export async function createInstantiator(options, swift) {
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_returnAnimatable"] = function bjs_returnAnimatable() {
                 try {
-                    let ret = options.imports.returnAnimatable();
+                    let ret = imports.returnAnimatable();
                     return swift.memory.retain(ret);
                 } catch (error) {
                     setException(error);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MultipleImportedTypes.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MultipleImportedTypes.Import.js
@@ -15,10 +15,13 @@ export async function createInstantiator(options, swift) {
     let tmpRetBytes;
     let tmpRetException;
     return {
-        /** @param {WebAssembly.Imports} importObject */
-        addImports: (importObject) => {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
             const bjs = {};
             importObject["bjs"] = bjs;
+            const imports = options.getImports(importsContext);
             bjs["swift_js_return_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
                 tmpRetString = textDecoder.decode(bytes);
@@ -50,7 +53,7 @@ export async function createInstantiator(options, swift) {
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_createDatabaseConnection"] = function bjs_createDatabaseConnection(config) {
                 try {
-                    let ret = options.imports.createDatabaseConnection(swift.memory.getObject(config));
+                    let ret = imports.createDatabaseConnection(swift.memory.getObject(config));
                     return swift.memory.retain(ret);
                 } catch (error) {
                     setException(error);
@@ -61,7 +64,7 @@ export async function createInstantiator(options, swift) {
                 try {
                     const levelObject = swift.memory.getObject(level);
                     swift.memory.release(level);
-                    let ret = options.imports.createLogger(levelObject);
+                    let ret = imports.createLogger(levelObject);
                     return swift.memory.retain(ret);
                 } catch (error) {
                     setException(error);
@@ -70,7 +73,7 @@ export async function createInstantiator(options, swift) {
             }
             TestModule["bjs_getConfigManager"] = function bjs_getConfigManager() {
                 try {
-                    let ret = options.imports.getConfigManager();
+                    let ret = imports.getConfigManager();
                     return swift.memory.retain(ret);
                 } catch (error) {
                     setException(error);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Export.js
@@ -15,10 +15,13 @@ export async function createInstantiator(options, swift) {
     let tmpRetBytes;
     let tmpRetException;
     return {
-        /** @param {WebAssembly.Imports} importObject */
-        addImports: (importObject) => {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
             const bjs = {};
             importObject["bjs"] = bjs;
+            const imports = options.getImports(importsContext);
             bjs["swift_js_return_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
                 tmpRetString = textDecoder.decode(bytes);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.Export.js
@@ -15,10 +15,13 @@ export async function createInstantiator(options, swift) {
     let tmpRetBytes;
     let tmpRetException;
     return {
-        /** @param {WebAssembly.Imports} importObject */
-        addImports: (importObject) => {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
             const bjs = {};
             importObject["bjs"] = bjs;
+            const imports = options.getImports(importsContext);
             bjs["swift_js_return_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
                 tmpRetString = textDecoder.decode(bytes);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.Import.js
@@ -15,10 +15,13 @@ export async function createInstantiator(options, swift) {
     let tmpRetBytes;
     let tmpRetException;
     return {
-        /** @param {WebAssembly.Imports} importObject */
-        addImports: (importObject) => {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
             const bjs = {};
             importObject["bjs"] = bjs;
+            const imports = options.getImports(importsContext);
             bjs["swift_js_return_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
                 tmpRetString = textDecoder.decode(bytes);
@@ -50,7 +53,7 @@ export async function createInstantiator(options, swift) {
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_check"] = function bjs_check(a, b) {
                 try {
-                    options.imports.check(a, b);
+                    imports.check(a, b);
                 } catch (error) {
                     setException(error);
                 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.Export.js
@@ -15,10 +15,13 @@ export async function createInstantiator(options, swift) {
     let tmpRetBytes;
     let tmpRetException;
     return {
-        /** @param {WebAssembly.Imports} importObject */
-        addImports: (importObject) => {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
             const bjs = {};
             importObject["bjs"] = bjs;
+            const imports = options.getImports(importsContext);
             bjs["swift_js_return_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
                 tmpRetString = textDecoder.decode(bytes);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.Import.js
@@ -15,10 +15,13 @@ export async function createInstantiator(options, swift) {
     let tmpRetBytes;
     let tmpRetException;
     return {
-        /** @param {WebAssembly.Imports} importObject */
-        addImports: (importObject) => {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
             const bjs = {};
             importObject["bjs"] = bjs;
+            const imports = options.getImports(importsContext);
             bjs["swift_js_return_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
                 tmpRetString = textDecoder.decode(bytes);
@@ -50,7 +53,7 @@ export async function createInstantiator(options, swift) {
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_checkNumber"] = function bjs_checkNumber() {
                 try {
-                    let ret = options.imports.checkNumber();
+                    let ret = imports.checkNumber();
                     return ret;
                 } catch (error) {
                     setException(error);
@@ -59,7 +62,7 @@ export async function createInstantiator(options, swift) {
             }
             TestModule["bjs_checkBoolean"] = function bjs_checkBoolean() {
                 try {
-                    let ret = options.imports.checkBoolean();
+                    let ret = imports.checkBoolean();
                     return ret !== 0;
                 } catch (error) {
                     setException(error);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.Export.js
@@ -15,10 +15,13 @@ export async function createInstantiator(options, swift) {
     let tmpRetBytes;
     let tmpRetException;
     return {
-        /** @param {WebAssembly.Imports} importObject */
-        addImports: (importObject) => {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
             const bjs = {};
             importObject["bjs"] = bjs;
+            const imports = options.getImports(importsContext);
             bjs["swift_js_return_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
                 tmpRetString = textDecoder.decode(bytes);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.Export.js
@@ -15,10 +15,13 @@ export async function createInstantiator(options, swift) {
     let tmpRetBytes;
     let tmpRetException;
     return {
-        /** @param {WebAssembly.Imports} importObject */
-        addImports: (importObject) => {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
             const bjs = {};
             importObject["bjs"] = bjs;
+            const imports = options.getImports(importsContext);
             bjs["swift_js_return_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
                 tmpRetString = textDecoder.decode(bytes);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.Import.js
@@ -15,10 +15,13 @@ export async function createInstantiator(options, swift) {
     let tmpRetBytes;
     let tmpRetException;
     return {
-        /** @param {WebAssembly.Imports} importObject */
-        addImports: (importObject) => {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
             const bjs = {};
             importObject["bjs"] = bjs;
+            const imports = options.getImports(importsContext);
             bjs["swift_js_return_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
                 tmpRetString = textDecoder.decode(bytes);
@@ -50,7 +53,7 @@ export async function createInstantiator(options, swift) {
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_checkString"] = function bjs_checkString() {
                 try {
-                    let ret = options.imports.checkString();
+                    let ret = imports.checkString();
                     tmpRetBytes = textEncoder.encode(ret);
                     return tmpRetBytes.length;
                 } catch (error) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.Export.js
@@ -15,10 +15,13 @@ export async function createInstantiator(options, swift) {
     let tmpRetBytes;
     let tmpRetException;
     return {
-        /** @param {WebAssembly.Imports} importObject */
-        addImports: (importObject) => {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
             const bjs = {};
             importObject["bjs"] = bjs;
+            const imports = options.getImports(importsContext);
             bjs["swift_js_return_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
                 tmpRetString = textDecoder.decode(bytes);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TS2SkeletonLike.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TS2SkeletonLike.Import.js
@@ -15,10 +15,13 @@ export async function createInstantiator(options, swift) {
     let tmpRetBytes;
     let tmpRetException;
     return {
-        /** @param {WebAssembly.Imports} importObject */
-        addImports: (importObject) => {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
             const bjs = {};
             importObject["bjs"] = bjs;
+            const imports = options.getImports(importsContext);
             bjs["swift_js_return_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
                 tmpRetString = textDecoder.decode(bytes);
@@ -50,7 +53,7 @@ export async function createInstantiator(options, swift) {
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_createTS2Skeleton"] = function bjs_createTS2Skeleton() {
                 try {
-                    let ret = options.imports.createTS2Skeleton();
+                    let ret = imports.createTS2Skeleton();
                     return swift.memory.retain(ret);
                 } catch (error) {
                     setException(error);
@@ -61,7 +64,7 @@ export async function createInstantiator(options, swift) {
                 try {
                     const formatObject = swift.memory.getObject(format);
                     swift.memory.release(format);
-                    let ret = options.imports.createCodeGenerator(formatObject);
+                    let ret = imports.createCodeGenerator(formatObject);
                     return swift.memory.retain(ret);
                 } catch (error) {
                     setException(error);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.Export.js
@@ -15,10 +15,13 @@ export async function createInstantiator(options, swift) {
     let tmpRetBytes;
     let tmpRetException;
     return {
-        /** @param {WebAssembly.Imports} importObject */
-        addImports: (importObject) => {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
             const bjs = {};
             importObject["bjs"] = bjs;
+            const imports = options.getImports(importsContext);
             bjs["swift_js_return_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
                 tmpRetString = textDecoder.decode(bytes);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TypeAlias.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TypeAlias.Import.js
@@ -15,10 +15,13 @@ export async function createInstantiator(options, swift) {
     let tmpRetBytes;
     let tmpRetException;
     return {
-        /** @param {WebAssembly.Imports} importObject */
-        addImports: (importObject) => {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
             const bjs = {};
             importObject["bjs"] = bjs;
+            const imports = options.getImports(importsContext);
             bjs["swift_js_return_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
                 tmpRetString = textDecoder.decode(bytes);
@@ -50,7 +53,7 @@ export async function createInstantiator(options, swift) {
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_checkSimple"] = function bjs_checkSimple(a) {
                 try {
-                    options.imports.checkSimple(a);
+                    imports.checkSimple(a);
                 } catch (error) {
                     setException(error);
                 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TypeScriptClass.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TypeScriptClass.Import.js
@@ -15,10 +15,13 @@ export async function createInstantiator(options, swift) {
     let tmpRetBytes;
     let tmpRetException;
     return {
-        /** @param {WebAssembly.Imports} importObject */
-        addImports: (importObject) => {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
             const bjs = {};
             importObject["bjs"] = bjs;
+            const imports = options.getImports(importsContext);
             bjs["swift_js_return_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
                 tmpRetString = textDecoder.decode(bytes);
@@ -52,7 +55,7 @@ export async function createInstantiator(options, swift) {
                 try {
                     const nameObject = swift.memory.getObject(name);
                     swift.memory.release(name);
-                    let ret = new options.imports.Greeter(nameObject);
+                    let ret = new imports.Greeter(nameObject);
                     return swift.memory.retain(ret);
                 } catch (error) {
                     setException(error);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.Export.js
@@ -15,10 +15,13 @@ export async function createInstantiator(options, swift) {
     let tmpRetBytes;
     let tmpRetException;
     return {
-        /** @param {WebAssembly.Imports} importObject */
-        addImports: (importObject) => {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
             const bjs = {};
             importObject["bjs"] = bjs;
+            const imports = options.getImports(importsContext);
             bjs["swift_js_return_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
                 tmpRetString = textDecoder.decode(bytes);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.Import.js
@@ -15,10 +15,13 @@ export async function createInstantiator(options, swift) {
     let tmpRetBytes;
     let tmpRetException;
     return {
-        /** @param {WebAssembly.Imports} importObject */
-        addImports: (importObject) => {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
             const bjs = {};
             importObject["bjs"] = bjs;
+            const imports = options.getImports(importsContext);
             bjs["swift_js_return_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
                 tmpRetString = textDecoder.decode(bytes);
@@ -50,7 +53,7 @@ export async function createInstantiator(options, swift) {
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_check"] = function bjs_check() {
                 try {
-                    options.imports.check();
+                    imports.check();
                 } catch (error) {
                     setException(error);
                 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Async.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Async.json
@@ -1,0 +1,168 @@
+{
+  "classes" : [
+
+  ],
+  "functions" : [
+    {
+      "abiName" : "bjs_asyncReturnVoid",
+      "effects" : {
+        "isAsync" : true,
+        "isThrows" : false
+      },
+      "name" : "asyncReturnVoid",
+      "parameters" : [
+
+      ],
+      "returnType" : {
+        "void" : {
+
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_asyncRoundTripInt",
+      "effects" : {
+        "isAsync" : true,
+        "isThrows" : false
+      },
+      "name" : "asyncRoundTripInt",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "v",
+          "type" : {
+            "int" : {
+
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "int" : {
+
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_asyncRoundTripString",
+      "effects" : {
+        "isAsync" : true,
+        "isThrows" : false
+      },
+      "name" : "asyncRoundTripString",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "v",
+          "type" : {
+            "string" : {
+
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "string" : {
+
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_asyncRoundTripBool",
+      "effects" : {
+        "isAsync" : true,
+        "isThrows" : false
+      },
+      "name" : "asyncRoundTripBool",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "v",
+          "type" : {
+            "bool" : {
+
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "bool" : {
+
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_asyncRoundTripFloat",
+      "effects" : {
+        "isAsync" : true,
+        "isThrows" : false
+      },
+      "name" : "asyncRoundTripFloat",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "v",
+          "type" : {
+            "float" : {
+
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "float" : {
+
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_asyncRoundTripDouble",
+      "effects" : {
+        "isAsync" : true,
+        "isThrows" : false
+      },
+      "name" : "asyncRoundTripDouble",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "v",
+          "type" : {
+            "double" : {
+
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "double" : {
+
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_asyncRoundTripJSObject",
+      "effects" : {
+        "isAsync" : true,
+        "isThrows" : false
+      },
+      "name" : "asyncRoundTripJSObject",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "v",
+          "type" : {
+            "jsObject" : {
+
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "jsObject" : {
+
+        }
+      }
+    }
+  ],
+  "moduleName" : "TestModule"
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Async.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Async.swift
@@ -1,0 +1,102 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+@_spi(BridgeJS) import JavaScriptKit
+
+@_expose(wasm, "bjs_asyncReturnVoid")
+@_cdecl("bjs_asyncReturnVoid")
+public func _bjs_asyncReturnVoid() -> Int32 {
+    #if arch(wasm32)
+    let ret = JSPromise.async {
+        await asyncReturnVoid()
+    } .jsObject
+    return _swift_js_retain(Int32(bitPattern: ret.id))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripInt")
+@_cdecl("bjs_asyncRoundTripInt")
+public func _bjs_asyncRoundTripInt(v: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = JSPromise.async {
+        return await asyncRoundTripInt(_: Int(v)).jsValue
+    } .jsObject
+    return _swift_js_retain(Int32(bitPattern: ret.id))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripString")
+@_cdecl("bjs_asyncRoundTripString")
+public func _bjs_asyncRoundTripString(vBytes: Int32, vLen: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = JSPromise.async {
+        let v = String(unsafeUninitializedCapacity: Int(vLen)) { b in
+            _swift_js_init_memory(vBytes, b.baseAddress.unsafelyUnwrapped)
+            return Int(vLen)
+        }
+        return await asyncRoundTripString(_: v).jsValue
+    } .jsObject
+    return _swift_js_retain(Int32(bitPattern: ret.id))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripBool")
+@_cdecl("bjs_asyncRoundTripBool")
+public func _bjs_asyncRoundTripBool(v: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = JSPromise.async {
+        return await asyncRoundTripBool(_: v == 1).jsValue
+    } .jsObject
+    return _swift_js_retain(Int32(bitPattern: ret.id))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripFloat")
+@_cdecl("bjs_asyncRoundTripFloat")
+public func _bjs_asyncRoundTripFloat(v: Float32) -> Int32 {
+    #if arch(wasm32)
+    let ret = JSPromise.async {
+        return await asyncRoundTripFloat(_: v).jsValue
+    } .jsObject
+    return _swift_js_retain(Int32(bitPattern: ret.id))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripDouble")
+@_cdecl("bjs_asyncRoundTripDouble")
+public func _bjs_asyncRoundTripDouble(v: Float64) -> Int32 {
+    #if arch(wasm32)
+    let ret = JSPromise.async {
+        return await asyncRoundTripDouble(_: v).jsValue
+    } .jsObject
+    return _swift_js_retain(Int32(bitPattern: ret.id))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripJSObject")
+@_cdecl("bjs_asyncRoundTripJSObject")
+public func _bjs_asyncRoundTripJSObject(v: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = JSPromise.async {
+        return await asyncRoundTripJSObject(_: JSObject(id: UInt32(bitPattern: v))).jsValue
+    } .jsObject
+    return _swift_js_retain(Int32(bitPattern: ret.id))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/Async.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/Async.swift
@@ -1,0 +1,123 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+@_spi(BridgeJS) import JavaScriptKit
+
+func asyncReturnVoid() throws(JSException) -> JSPromise {
+    #if arch(wasm32)
+    @_extern(wasm, module: "Check", name: "bjs_asyncReturnVoid")
+    func bjs_asyncReturnVoid() -> Int32
+    #else
+    func bjs_asyncReturnVoid() -> Int32 {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
+    let ret = bjs_asyncReturnVoid()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSPromise(takingThis: ret)
+}
+
+func asyncRoundTripInt(_ v: Double) throws(JSException) -> JSPromise {
+    #if arch(wasm32)
+    @_extern(wasm, module: "Check", name: "bjs_asyncRoundTripInt")
+    func bjs_asyncRoundTripInt(_ v: Float64) -> Int32
+    #else
+    func bjs_asyncRoundTripInt(_ v: Float64) -> Int32 {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
+    let ret = bjs_asyncRoundTripInt(v)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSPromise(takingThis: ret)
+}
+
+func asyncRoundTripString(_ v: String) throws(JSException) -> JSPromise {
+    #if arch(wasm32)
+    @_extern(wasm, module: "Check", name: "bjs_asyncRoundTripString")
+    func bjs_asyncRoundTripString(_ v: Int32) -> Int32
+    #else
+    func bjs_asyncRoundTripString(_ v: Int32) -> Int32 {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
+    var v = v
+    let vId = v.withUTF8 { b in
+        _swift_js_make_js_string(b.baseAddress.unsafelyUnwrapped, Int32(b.count))
+    }
+    let ret = bjs_asyncRoundTripString(vId)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSPromise(takingThis: ret)
+}
+
+func asyncRoundTripBool(_ v: Bool) throws(JSException) -> JSPromise {
+    #if arch(wasm32)
+    @_extern(wasm, module: "Check", name: "bjs_asyncRoundTripBool")
+    func bjs_asyncRoundTripBool(_ v: Int32) -> Int32
+    #else
+    func bjs_asyncRoundTripBool(_ v: Int32) -> Int32 {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
+    let ret = bjs_asyncRoundTripBool(Int32(v ? 1 : 0))
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSPromise(takingThis: ret)
+}
+
+func asyncRoundTripFloat(_ v: Double) throws(JSException) -> JSPromise {
+    #if arch(wasm32)
+    @_extern(wasm, module: "Check", name: "bjs_asyncRoundTripFloat")
+    func bjs_asyncRoundTripFloat(_ v: Float64) -> Int32
+    #else
+    func bjs_asyncRoundTripFloat(_ v: Float64) -> Int32 {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
+    let ret = bjs_asyncRoundTripFloat(v)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSPromise(takingThis: ret)
+}
+
+func asyncRoundTripDouble(_ v: Double) throws(JSException) -> JSPromise {
+    #if arch(wasm32)
+    @_extern(wasm, module: "Check", name: "bjs_asyncRoundTripDouble")
+    func bjs_asyncRoundTripDouble(_ v: Float64) -> Int32
+    #else
+    func bjs_asyncRoundTripDouble(_ v: Float64) -> Int32 {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
+    let ret = bjs_asyncRoundTripDouble(v)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSPromise(takingThis: ret)
+}
+
+func asyncRoundTripJSObject(_ v: JSObject) throws(JSException) -> JSPromise {
+    #if arch(wasm32)
+    @_extern(wasm, module: "Check", name: "bjs_asyncRoundTripJSObject")
+    func bjs_asyncRoundTripJSObject(_ v: Int32) -> Int32
+    #else
+    func bjs_asyncRoundTripJSObject(_ v: Int32) -> Int32 {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
+    let ret = bjs_asyncRoundTripJSObject(Int32(bitPattern: v.id))
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSPromise(takingThis: ret)
+}

--- a/Plugins/PackageToJS/Templates/index.d.ts
+++ b/Plugins/PackageToJS/Templates/index.d.ts
@@ -11,7 +11,7 @@ export type Options = {
     /**
      * The imports to use for the module
      */
-    imports: Imports
+    getImports: () => Imports
 /* #endif */
 }
 

--- a/Plugins/PackageToJS/Templates/index.js
+++ b/Plugins/PackageToJS/Templates/index.js
@@ -8,7 +8,7 @@ export async function init(_options) {
     const options = _options || {
 /* #if HAS_IMPORTS */
         /** @returns {import('./instantiate.d').Imports} */
-        get imports() { (() => { throw new Error("No imports provided") })() }
+        getImports() { (() => { throw new Error("No imports provided") })() }
 /* #endif */
     };
     let module = options.module;
@@ -18,7 +18,7 @@ export async function init(_options) {
     const instantiateOptions = await defaultBrowserSetup({
         module,
 /* #if HAS_IMPORTS */
-        imports: options.imports,
+        getImports: () => options.getImports(),
 /* #endif */
 /* #if USE_SHARED_MEMORY */
         spawnWorker: createDefaultWorkerFactory()

--- a/Plugins/PackageToJS/Templates/instantiate.d.ts
+++ b/Plugins/PackageToJS/Templates/instantiate.d.ts
@@ -75,9 +75,13 @@ export type InstantiateOptions = {
     module: ModuleSource,
 /* #if HAS_IMPORTS */
     /**
-     * The imports provided by the embedder
+     * The function to get the imports provided by the embedder
      */
-    imports: Imports,
+    getImports: (importsContext: {
+        getInstance: () => WebAssembly.Instance | null,
+        getExports: () => Exports | null,
+        _swift: SwiftRuntime,
+    }) => Imports,
 /* #endif */
 /* #if IS_WASI */
     /**

--- a/Plugins/PackageToJS/Templates/instantiate.js
+++ b/Plugins/PackageToJS/Templates/instantiate.js
@@ -23,8 +23,11 @@ import { createInstantiator } from "./bridge-js.js"
  */
 async function createInstantiator(options, swift) {
     return {
-        /** @param {WebAssembly.Imports} importObject */
-        addImports: (importObject) => {},
+        /**
+         * @param {WebAssembly.Imports} importObject
+         * @param {unknown} importsContext
+         */
+        addImports: (importObject, importsContext) => {},
         /** @param {WebAssembly.Instance} instance */
         setInstance: (instance) => {},
         /** @param {WebAssembly.Instance} instance */
@@ -93,12 +96,13 @@ async function _instantiate(
 /* #endif */
 /* #endif */
     };
-    instantiator.addImports(importObject);
-    options.addToCoreImports?.(importObject, {
+    const importsContext = {
         getInstance: () => instance,
         getExports: () => exports,
         _swift: swift,
-    });
+    };
+    instantiator.addImports(importObject, importsContext);
+    options.addToCoreImports?.(importObject, importsContext);
 
     let module;
     let instance;

--- a/Plugins/PackageToJS/Templates/platforms/browser.d.ts
+++ b/Plugins/PackageToJS/Templates/platforms/browser.d.ts
@@ -8,7 +8,7 @@ export function defaultBrowserSetup(options: {
     onStderrLine?: (line: string) => void,
 /* #endif */
 /* #if HAS_IMPORTS */
-    imports: Imports,
+    getImports: () => Imports,
 /* #endif */
 /* #if USE_SHARED_MEMORY */
     spawnWorker: (module: WebAssembly.Module, memory: WebAssembly.Memory, startArg: any) => Worker,

--- a/Plugins/PackageToJS/Templates/platforms/browser.js
+++ b/Plugins/PackageToJS/Templates/platforms/browser.js
@@ -124,7 +124,7 @@ export async function defaultBrowserSetup(options) {
     return {
         module: options.module,
 /* #if HAS_IMPORTS */
-        imports: options.imports,
+        getImports() { return options.getImports() },
 /* #endif */
 /* #if IS_WASI */
         wasi: Object.assign(wasi, {

--- a/Plugins/PackageToJS/Templates/platforms/browser.worker.js
+++ b/Plugins/PackageToJS/Templates/platforms/browser.worker.js
@@ -13,6 +13,6 @@ self.onmessage = async (event) => {
     await instantiateForThread(tid, startArg, {
         ...options,
         module, memory,
-        imports: {},
+        getImports() { return {} },
     })
 }

--- a/Plugins/PackageToJS/Templates/platforms/node.js
+++ b/Plugins/PackageToJS/Templates/platforms/node.js
@@ -65,7 +65,7 @@ export function createDefaultWorkerFactory(preludeScript) {
                 await instantiateForThread(tid, startArg, {
                     ...options,
                     module, memory,
-                    imports: {},
+                    getImports() { return {} },
                 })
             })
             `,
@@ -139,7 +139,7 @@ export async function defaultNodeSetup(options) {
 
     return {
         module,
-        imports: {},
+        getImports() { return {} },
 /* #if IS_WASI */
         wasi: Object.assign(wasi, {
             setInstance(instance) {

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/Importing-TypeScript-into-Swift.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/Importing-TypeScript-into-Swift.md
@@ -62,7 +62,7 @@ interface Document {
     // Properties
     title: string;
     readonly body: HTMLElement;
- 
+
     // Methods
     getElementById(id: string): HTMLElement;
     createElement(tagName: string): HTMLElement;
@@ -96,7 +96,7 @@ struct Document {
 struct HTMLElement {
     var innerText: String { get set }
     var className: String { get set }
-    
+
     func appendChild(_ child: HTMLElement)
 }
 
@@ -161,11 +161,13 @@ import { init } from "./.build/plugins/PackageToJS/outputs/Package/index.js";
 
 // Initialize the WebAssembly module with JavaScript implementations
 const { exports } = await init({
-    imports: {
-        consoleLog: (message) => {
-            console.log(message);
-        },
-        getDocument: () => document,
+    getImports() {
+        return {
+            consoleLog: (message) => {
+                console.log(message);
+            },
+            getDocument: () => document,
+        }
     }
 });
 

--- a/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
+++ b/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import JavaScriptKit
+import JavaScriptEventLoop
 
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "runJsWorks")
 @_extern(c)
@@ -48,6 +49,15 @@ struct TestError: Error {
 @JS func throwsWithDoubleResult() throws(JSException) -> Double { return 1.0 }
 @JS func throwsWithSwiftHeapObjectResult() throws(JSException) -> Greeter { return Greeter(name: "Test") }
 @JS func throwsWithJSObjectResult() throws(JSException) -> JSObject { return JSObject() }
+
+@JS func asyncRoundTripVoid() async -> Void { return }
+@JS func asyncRoundTripInt(v: Int) async -> Int { return v }
+@JS func asyncRoundTripFloat(v: Float) async -> Float { return v }
+@JS func asyncRoundTripDouble(v: Double) async -> Double { return v }
+@JS func asyncRoundTripBool(v: Bool) async -> Bool { return v }
+@JS func asyncRoundTripString(v: String) async -> String { return v }
+@JS func asyncRoundTripSwiftHeapObject(v: Greeter) async -> Greeter { return v }
+@JS func asyncRoundTripJSObject(v: JSObject) async -> JSObject { return v }
 
 @JS class Greeter {
     var name: String
@@ -130,5 +140,9 @@ class ExportAPITests: XCTestCase {
 
         XCTAssertTrue(hasDeinitGreeter, "Greeter (with @JS init) should have been deinitialized")
         XCTAssertTrue(hasDeinitCalculator, "Calculator (without @JS init) should have been deinitialized")
+    }
+
+    func testAllAsync() async throws {
+        _ = try await runAsyncWorks().value()
     }
 }

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.ExportSwift.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.ExportSwift.swift
@@ -300,6 +300,114 @@ public func _bjs_throwsWithJSObjectResult() -> Int32 {
     #endif
 }
 
+@_expose(wasm, "bjs_asyncRoundTripVoid")
+@_cdecl("bjs_asyncRoundTripVoid")
+public func _bjs_asyncRoundTripVoid() -> Int32 {
+    #if arch(wasm32)
+    let ret = JSPromise.async {
+        await asyncRoundTripVoid()
+    } .jsObject
+    return _swift_js_retain(Int32(bitPattern: ret.id))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripInt")
+@_cdecl("bjs_asyncRoundTripInt")
+public func _bjs_asyncRoundTripInt(v: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = JSPromise.async {
+        return await asyncRoundTripInt(v: Int(v)).jsValue
+    } .jsObject
+    return _swift_js_retain(Int32(bitPattern: ret.id))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripFloat")
+@_cdecl("bjs_asyncRoundTripFloat")
+public func _bjs_asyncRoundTripFloat(v: Float32) -> Int32 {
+    #if arch(wasm32)
+    let ret = JSPromise.async {
+        return await asyncRoundTripFloat(v: v).jsValue
+    } .jsObject
+    return _swift_js_retain(Int32(bitPattern: ret.id))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripDouble")
+@_cdecl("bjs_asyncRoundTripDouble")
+public func _bjs_asyncRoundTripDouble(v: Float64) -> Int32 {
+    #if arch(wasm32)
+    let ret = JSPromise.async {
+        return await asyncRoundTripDouble(v: v).jsValue
+    } .jsObject
+    return _swift_js_retain(Int32(bitPattern: ret.id))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripBool")
+@_cdecl("bjs_asyncRoundTripBool")
+public func _bjs_asyncRoundTripBool(v: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = JSPromise.async {
+        return await asyncRoundTripBool(v: v == 1).jsValue
+    } .jsObject
+    return _swift_js_retain(Int32(bitPattern: ret.id))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripString")
+@_cdecl("bjs_asyncRoundTripString")
+public func _bjs_asyncRoundTripString(vBytes: Int32, vLen: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = JSPromise.async {
+        let v = String(unsafeUninitializedCapacity: Int(vLen)) { b in
+            _swift_js_init_memory(vBytes, b.baseAddress.unsafelyUnwrapped)
+            return Int(vLen)
+        }
+        return await asyncRoundTripString(v: v).jsValue
+    } .jsObject
+    return _swift_js_retain(Int32(bitPattern: ret.id))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripSwiftHeapObject")
+@_cdecl("bjs_asyncRoundTripSwiftHeapObject")
+public func _bjs_asyncRoundTripSwiftHeapObject(v: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = JSPromise.async {
+        return await asyncRoundTripSwiftHeapObject(v: Unmanaged<Greeter>.fromOpaque(v).takeUnretainedValue()).jsValue
+    } .jsObject
+    return _swift_js_retain(Int32(bitPattern: ret.id))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripJSObject")
+@_cdecl("bjs_asyncRoundTripJSObject")
+public func _bjs_asyncRoundTripJSObject(v: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = JSPromise.async {
+        return await asyncRoundTripJSObject(v: JSObject(id: UInt32(bitPattern: v))).jsValue
+    } .jsObject
+    return _swift_js_retain(Int32(bitPattern: ret.id))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs_takeGreeter")
 @_cdecl("bjs_takeGreeter")
 public func _bjs_takeGreeter(g: UnsafeMutableRawPointer, nameBytes: Int32, nameLen: Int32) -> Void {

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.ImportTS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.ImportTS.swift
@@ -142,6 +142,22 @@ func jsThrowOrString(_ shouldThrow: Bool) throws(JSException) -> String {
     }
 }
 
+func runAsyncWorks() throws(JSException) -> JSPromise {
+    #if arch(wasm32)
+    @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_runAsyncWorks")
+    func bjs_runAsyncWorks() -> Int32
+    #else
+    func bjs_runAsyncWorks() -> Int32 {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
+    let ret = bjs_runAsyncWorks()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSPromise(takingThis: ret)
+}
+
 struct JsGreeter {
     let this: JSObject
 

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.ExportSwift.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.ExportSwift.json
@@ -448,6 +448,190 @@
       }
     },
     {
+      "abiName" : "bjs_asyncRoundTripVoid",
+      "effects" : {
+        "isAsync" : true,
+        "isThrows" : false
+      },
+      "name" : "asyncRoundTripVoid",
+      "parameters" : [
+
+      ],
+      "returnType" : {
+        "void" : {
+
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_asyncRoundTripInt",
+      "effects" : {
+        "isAsync" : true,
+        "isThrows" : false
+      },
+      "name" : "asyncRoundTripInt",
+      "parameters" : [
+        {
+          "label" : "v",
+          "name" : "v",
+          "type" : {
+            "int" : {
+
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "int" : {
+
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_asyncRoundTripFloat",
+      "effects" : {
+        "isAsync" : true,
+        "isThrows" : false
+      },
+      "name" : "asyncRoundTripFloat",
+      "parameters" : [
+        {
+          "label" : "v",
+          "name" : "v",
+          "type" : {
+            "float" : {
+
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "float" : {
+
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_asyncRoundTripDouble",
+      "effects" : {
+        "isAsync" : true,
+        "isThrows" : false
+      },
+      "name" : "asyncRoundTripDouble",
+      "parameters" : [
+        {
+          "label" : "v",
+          "name" : "v",
+          "type" : {
+            "double" : {
+
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "double" : {
+
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_asyncRoundTripBool",
+      "effects" : {
+        "isAsync" : true,
+        "isThrows" : false
+      },
+      "name" : "asyncRoundTripBool",
+      "parameters" : [
+        {
+          "label" : "v",
+          "name" : "v",
+          "type" : {
+            "bool" : {
+
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "bool" : {
+
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_asyncRoundTripString",
+      "effects" : {
+        "isAsync" : true,
+        "isThrows" : false
+      },
+      "name" : "asyncRoundTripString",
+      "parameters" : [
+        {
+          "label" : "v",
+          "name" : "v",
+          "type" : {
+            "string" : {
+
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "string" : {
+
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_asyncRoundTripSwiftHeapObject",
+      "effects" : {
+        "isAsync" : true,
+        "isThrows" : false
+      },
+      "name" : "asyncRoundTripSwiftHeapObject",
+      "parameters" : [
+        {
+          "label" : "v",
+          "name" : "v",
+          "type" : {
+            "swiftHeapObject" : {
+              "_0" : "Greeter"
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "swiftHeapObject" : {
+          "_0" : "Greeter"
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_asyncRoundTripJSObject",
+      "effects" : {
+        "isAsync" : true,
+        "isThrows" : false
+      },
+      "name" : "asyncRoundTripJSObject",
+      "parameters" : [
+        {
+          "label" : "v",
+          "name" : "v",
+          "type" : {
+            "jsObject" : {
+
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "jsObject" : {
+
+        }
+      }
+    },
+    {
       "abiName" : "bjs_takeGreeter",
       "effects" : {
         "isAsync" : false,

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.ImportTS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.ImportTS.json
@@ -138,6 +138,17 @@
 
             }
           }
+        },
+        {
+          "name" : "runAsyncWorks",
+          "parameters" : [
+
+          ],
+          "returnType" : {
+            "jsObject" : {
+              "_0" : "JSPromise"
+            }
+          }
         }
       ],
       "types" : [

--- a/Tests/BridgeJSRuntimeTests/bridge-js.d.ts
+++ b/Tests/BridgeJSRuntimeTests/bridge-js.d.ts
@@ -14,3 +14,5 @@ export class JsGreeter {
     greet(): string;
     changeName(name: string): void;
 }
+
+export function runAsyncWorks(): Promise<void>;


### PR DESCRIPTION
This PR adds comprehensive async function support to BridgeJS, enabling seamless interoperability between Swift async functions and JavaScript Promises.
Swift functions marked with `async` are now automatically exposed as JavaScript functions returning `Promise<T>`

### Implementation Details

#### Core Changes
- **ExportSwift.swift**: Modified to detect async functions and wrap calls with `JSPromise.async`, handling proper return value conversion
- **BridgeJSLink.swift**: Updated TypeScript signature generation to emit `Promise<T>` for async functions
- **TypeScript processor**: Enhanced to recognize Promise types and generate appropriate bridge types

#### API Changes  
- **Import initialization**: Changed from `imports: {...}` to `getImports() { return {...} }` pattern to allow accessing `exports` inside imports implementation.

### Example Usage

**Swift side:**
```swift
@JS func fetchUserData(_ userId: String) async -> String {
    // Async Swift implementation
    return userData
}
```

**Generated JavaScript/TypeScript:**
```typescript
export type Exports = {
    fetchUserData(userId: string): Promise<string>;
}
```

This enhancement significantly improves the developer experience when working with async Swift code in JavaScript environments, providing type-safe Promise-based APIs that feel natural in both languages.