### PR TITLE
BridgeJS: Fix missing TypeScript interface definitions for imported types

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -221,6 +221,7 @@ struct BridgeJSLink {
         var dtsLines: [String] = []
         dtsLines.append(contentsOf: namespaceDeclarations())
         dtsLines.append(contentsOf: dtsClassLines)
+        dtsLines.append(contentsOf: generateImportedTypeDefinitions())
         dtsLines.append("export type Exports = {")
         dtsLines.append(contentsOf: dtsExportLines.map { $0.indent(count: 4) })
         dtsLines.append("}")
@@ -244,6 +245,38 @@ struct BridgeJSLink {
             }>;
             """
         return (outputJs, outputDts)
+    }
+
+    private func generateImportedTypeDefinitions() -> [String] {
+        var typeDefinitions: [String] = []
+
+        for skeletonSet in importedSkeletons {
+            for fileSkeleton in skeletonSet.children {
+                for type in fileSkeleton.types {
+                    typeDefinitions.append("export interface \(type.name) {")
+
+                    // Add methods
+                    for method in type.methods {
+                        let methodSignature =
+                            "\(method.name)\(renderTSSignature(parameters: method.parameters, returnType: method.returnType));"
+                        typeDefinitions.append(methodSignature.indent(count: 4))
+                    }
+
+                    // Add properties
+                    for property in type.properties {
+                        let propertySignature =
+                            property.isReadonly
+                            ? "readonly \(property.name): \(property.type.tsType);"
+                            : "\(property.name): \(property.type.tsType);"
+                        typeDefinitions.append(propertySignature.indent(count: 4))
+                    }
+
+                    typeDefinitions.append("}")
+                }
+            }
+        }
+
+        return typeDefinitions
     }
 
     private func namespaceDeclarations() -> [String] {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MultipleImportedTypes.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MultipleImportedTypes.d.ts
@@ -1,0 +1,23 @@
+// Test case for multiple imported types with methods and properties
+export interface DatabaseConnection {
+    connect(url: string): void;
+    execute(query: string): any;
+    readonly isConnected: boolean;
+    connectionTimeout: number;
+}
+
+export interface Logger {
+    log(message: string): void;
+    error(message: string, error: any): void;
+    readonly level: string;
+}
+
+export interface ConfigManager {
+    get(key: string): any;
+    set(key: string, value: any): void;
+    readonly configPath: string;
+}
+
+export function createDatabaseConnection(config: any): DatabaseConnection;
+export function createLogger(level: string): Logger;
+export function getConfigManager(): ConfigManager;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/TS2SkeletonLike.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/TS2SkeletonLike.d.ts
@@ -1,0 +1,14 @@
+// Test case similar to the TS2Skeleton use case that caused the original bug
+export interface TypeScriptProcessor {
+    convert(ts: string): string;
+    validate(ts: string): boolean;
+    readonly version: string;
+}
+
+export interface CodeGenerator {
+    generate(input: any): string;
+    readonly outputFormat: string;
+}
+
+export function createTS2Skeleton(): TypeScriptProcessor;
+export function createCodeGenerator(format: string): CodeGenerator;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Interface.Import.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Interface.Import.d.ts
@@ -4,6 +4,10 @@
 // To update this file, just rebuild your project or run
 // `swift package bridge-js`.
 
+export interface Animatable {
+    animate(keyframes: any, options: any): any;
+    getAnimations(options: any): any;
+}
 export type Exports = {
 }
 export type Imports = {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MultipleImportedTypes.Import.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MultipleImportedTypes.Import.d.ts
@@ -1,0 +1,36 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export interface DatabaseConnection {
+    connect(url: string): void;
+    execute(query: string): any;
+    readonly isConnected: boolean;
+    connectionTimeout: number;
+}
+export interface Logger {
+    log(message: string): void;
+    error(message: string, error: any): void;
+    readonly level: string;
+}
+export interface ConfigManager {
+    get(key: string): any;
+    set(key: string, value: any): void;
+    readonly configPath: string;
+}
+export type Exports = {
+}
+export type Imports = {
+    createDatabaseConnection(config: any): DatabaseConnection;
+    createLogger(level: string): Logger;
+    getConfigManager(): ConfigManager;
+}
+export function createInstantiator(options: {
+    imports: Imports;
+}, swift: any): Promise<{
+    addImports: (importObject: WebAssembly.Imports) => void;
+    setInstance: (instance: WebAssembly.Instance) => void;
+    createExports: (instance: WebAssembly.Instance) => Exports;
+}>;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MultipleImportedTypes.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MultipleImportedTypes.Import.js
@@ -1,0 +1,198 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export async function createInstantiator(options, swift) {
+    let instance;
+    let memory;
+    let setException;
+    const textDecoder = new TextDecoder("utf-8");
+    const textEncoder = new TextEncoder("utf-8");
+
+    let tmpRetString;
+    let tmpRetBytes;
+    let tmpRetException;
+    return {
+        /** @param {WebAssembly.Imports} importObject */
+        addImports: (importObject) => {
+            const bjs = {};
+            importObject["bjs"] = bjs;
+            bjs["swift_js_return_string"] = function(ptr, len) {
+                const bytes = new Uint8Array(memory.buffer, ptr, len);
+                tmpRetString = textDecoder.decode(bytes);
+            }
+            bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
+                const source = swift.memory.getObject(sourceId);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                bytes.set(source);
+            }
+            bjs["swift_js_make_js_string"] = function(ptr, len) {
+                const bytes = new Uint8Array(memory.buffer, ptr, len);
+                return swift.memory.retain(textDecoder.decode(bytes));
+            }
+            bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
+                const target = new Uint8Array(memory.buffer, ptr, len);
+                target.set(tmpRetBytes);
+                tmpRetBytes = undefined;
+            }
+            bjs["swift_js_throw"] = function(id) {
+                tmpRetException = swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_retain"] = function(id) {
+                return swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_release"] = function(id) {
+                swift.memory.release(id);
+            }
+            const TestModule = importObject["TestModule"] = {};
+            TestModule["bjs_createDatabaseConnection"] = function bjs_createDatabaseConnection(config) {
+                try {
+                    let ret = options.imports.createDatabaseConnection(swift.memory.getObject(config));
+                    return swift.memory.retain(ret);
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_createLogger"] = function bjs_createLogger(level) {
+                try {
+                    const levelObject = swift.memory.getObject(level);
+                    swift.memory.release(level);
+                    let ret = options.imports.createLogger(levelObject);
+                    return swift.memory.retain(ret);
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_getConfigManager"] = function bjs_getConfigManager() {
+                try {
+                    let ret = options.imports.getConfigManager();
+                    return swift.memory.retain(ret);
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_DatabaseConnection_isConnected_get"] = function bjs_DatabaseConnection_isConnected_get(self) {
+                try {
+                    let ret = swift.memory.getObject(self).isConnected;
+                    return ret !== 0;
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_DatabaseConnection_connectionTimeout_get"] = function bjs_DatabaseConnection_connectionTimeout_get(self) {
+                try {
+                    let ret = swift.memory.getObject(self).connectionTimeout;
+                    return ret;
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_DatabaseConnection_connectionTimeout_set"] = function bjs_DatabaseConnection_connectionTimeout_set(self, newValue) {
+                try {
+                    swift.memory.getObject(self).connectionTimeout = newValue;
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_DatabaseConnection_connect"] = function bjs_DatabaseConnection_connect(self, url) {
+                try {
+                    const urlObject = swift.memory.getObject(url);
+                    swift.memory.release(url);
+                    swift.memory.getObject(self).connect(urlObject);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_DatabaseConnection_execute"] = function bjs_DatabaseConnection_execute(self, query) {
+                try {
+                    const queryObject = swift.memory.getObject(query);
+                    swift.memory.release(query);
+                    let ret = swift.memory.getObject(self).execute(queryObject);
+                    return swift.memory.retain(ret);
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_Logger_level_get"] = function bjs_Logger_level_get(self) {
+                try {
+                    let ret = swift.memory.getObject(self).level;
+                    tmpRetBytes = textEncoder.encode(ret);
+                    return tmpRetBytes.length;
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_Logger_log"] = function bjs_Logger_log(self, message) {
+                try {
+                    const messageObject = swift.memory.getObject(message);
+                    swift.memory.release(message);
+                    swift.memory.getObject(self).log(messageObject);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_Logger_error"] = function bjs_Logger_error(self, message, error) {
+                try {
+                    const messageObject = swift.memory.getObject(message);
+                    swift.memory.release(message);
+                    swift.memory.getObject(self).error(messageObject, swift.memory.getObject(error));
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_ConfigManager_configPath_get"] = function bjs_ConfigManager_configPath_get(self) {
+                try {
+                    let ret = swift.memory.getObject(self).configPath;
+                    tmpRetBytes = textEncoder.encode(ret);
+                    return tmpRetBytes.length;
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_ConfigManager_get"] = function bjs_ConfigManager_get(self, key) {
+                try {
+                    const keyObject = swift.memory.getObject(key);
+                    swift.memory.release(key);
+                    let ret = swift.memory.getObject(self).get(keyObject);
+                    return swift.memory.retain(ret);
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_ConfigManager_set"] = function bjs_ConfigManager_set(self, key, value) {
+                try {
+                    const keyObject = swift.memory.getObject(key);
+                    swift.memory.release(key);
+                    swift.memory.getObject(self).set(keyObject, swift.memory.getObject(value));
+                } catch (error) {
+                    setException(error);
+                }
+            }
+        },
+        setInstance: (i) => {
+            instance = i;
+            memory = instance.exports.memory;
+            setException = (error) => {
+                instance.exports._swift_js_exception.value = swift.memory.retain(error)
+            }
+        },
+        /** @param {WebAssembly.Instance} instance */
+        createExports: (instance) => {
+            const js = swift.memory.heap;
+
+            return {
+
+            };
+        },
+    }
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TS2SkeletonLike.Import.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TS2SkeletonLike.Import.d.ts
@@ -4,18 +4,20 @@
 // To update this file, just rebuild your project or run
 // `swift package bridge-js`.
 
-export interface Greeter {
-    greet(): string;
-    changeName(name: string): void;
-    name: string;
-    readonly age: number;
+export interface TypeScriptProcessor {
+    convert(ts: string): string;
+    validate(ts: string): boolean;
+    readonly version: string;
+}
+export interface CodeGenerator {
+    generate(input: any): string;
+    readonly outputFormat: string;
 }
 export type Exports = {
 }
 export type Imports = {
-    Greeter: {
-        new(name: string): Greeter;
-    }
+    createTS2Skeleton(): TypeScriptProcessor;
+    createCodeGenerator(format: string): CodeGenerator;
 }
 export function createInstantiator(options: {
     imports: Imports;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TS2SkeletonLike.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TS2SkeletonLike.Import.js
@@ -1,0 +1,136 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export async function createInstantiator(options, swift) {
+    let instance;
+    let memory;
+    let setException;
+    const textDecoder = new TextDecoder("utf-8");
+    const textEncoder = new TextEncoder("utf-8");
+
+    let tmpRetString;
+    let tmpRetBytes;
+    let tmpRetException;
+    return {
+        /** @param {WebAssembly.Imports} importObject */
+        addImports: (importObject) => {
+            const bjs = {};
+            importObject["bjs"] = bjs;
+            bjs["swift_js_return_string"] = function(ptr, len) {
+                const bytes = new Uint8Array(memory.buffer, ptr, len);
+                tmpRetString = textDecoder.decode(bytes);
+            }
+            bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
+                const source = swift.memory.getObject(sourceId);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                bytes.set(source);
+            }
+            bjs["swift_js_make_js_string"] = function(ptr, len) {
+                const bytes = new Uint8Array(memory.buffer, ptr, len);
+                return swift.memory.retain(textDecoder.decode(bytes));
+            }
+            bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
+                const target = new Uint8Array(memory.buffer, ptr, len);
+                target.set(tmpRetBytes);
+                tmpRetBytes = undefined;
+            }
+            bjs["swift_js_throw"] = function(id) {
+                tmpRetException = swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_retain"] = function(id) {
+                return swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_release"] = function(id) {
+                swift.memory.release(id);
+            }
+            const TestModule = importObject["TestModule"] = {};
+            TestModule["bjs_createTS2Skeleton"] = function bjs_createTS2Skeleton() {
+                try {
+                    let ret = options.imports.createTS2Skeleton();
+                    return swift.memory.retain(ret);
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_createCodeGenerator"] = function bjs_createCodeGenerator(format) {
+                try {
+                    const formatObject = swift.memory.getObject(format);
+                    swift.memory.release(format);
+                    let ret = options.imports.createCodeGenerator(formatObject);
+                    return swift.memory.retain(ret);
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_TypeScriptProcessor_version_get"] = function bjs_TypeScriptProcessor_version_get(self) {
+                try {
+                    let ret = swift.memory.getObject(self).version;
+                    tmpRetBytes = textEncoder.encode(ret);
+                    return tmpRetBytes.length;
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_TypeScriptProcessor_convert"] = function bjs_TypeScriptProcessor_convert(self, ts) {
+                try {
+                    const tsObject = swift.memory.getObject(ts);
+                    swift.memory.release(ts);
+                    let ret = swift.memory.getObject(self).convert(tsObject);
+                    tmpRetBytes = textEncoder.encode(ret);
+                    return tmpRetBytes.length;
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_TypeScriptProcessor_validate"] = function bjs_TypeScriptProcessor_validate(self, ts) {
+                try {
+                    const tsObject = swift.memory.getObject(ts);
+                    swift.memory.release(ts);
+                    let ret = swift.memory.getObject(self).validate(tsObject);
+                    return ret !== 0;
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_CodeGenerator_outputFormat_get"] = function bjs_CodeGenerator_outputFormat_get(self) {
+                try {
+                    let ret = swift.memory.getObject(self).outputFormat;
+                    tmpRetBytes = textEncoder.encode(ret);
+                    return tmpRetBytes.length;
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_CodeGenerator_generate"] = function bjs_CodeGenerator_generate(self, input) {
+                try {
+                    let ret = swift.memory.getObject(self).generate(swift.memory.getObject(input));
+                    tmpRetBytes = textEncoder.encode(ret);
+                    return tmpRetBytes.length;
+                } catch (error) {
+                    setException(error);
+                }
+            }
+        },
+        setInstance: (i) => {
+            instance = i;
+            memory = instance.exports.memory;
+            setException = (error) => {
+                instance.exports._swift_js_exception.value = swift.memory.retain(error)
+            }
+        },
+        /** @param {WebAssembly.Instance} instance */
+        createExports: (instance) => {
+            const js = swift.memory.heap;
+
+            return {
+
+            };
+        },
+    }
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/MultipleImportedTypes.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/MultipleImportedTypes.swift
@@ -1,0 +1,307 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+@_spi(BridgeJS) import JavaScriptKit
+
+func createDatabaseConnection(_ config: JSObject) throws(JSException) -> DatabaseConnection {
+    #if arch(wasm32)
+    @_extern(wasm, module: "Check", name: "bjs_createDatabaseConnection")
+    func bjs_createDatabaseConnection(_ config: Int32) -> Int32
+    #else
+    func bjs_createDatabaseConnection(_ config: Int32) -> Int32 {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
+    let ret = bjs_createDatabaseConnection(Int32(bitPattern: config.id))
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return DatabaseConnection(takingThis: ret)
+}
+
+func createLogger(_ level: String) throws(JSException) -> Logger {
+    #if arch(wasm32)
+    @_extern(wasm, module: "Check", name: "bjs_createLogger")
+    func bjs_createLogger(_ level: Int32) -> Int32
+    #else
+    func bjs_createLogger(_ level: Int32) -> Int32 {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
+    var level = level
+    let levelId = level.withUTF8 { b in
+        _swift_js_make_js_string(b.baseAddress.unsafelyUnwrapped, Int32(b.count))
+    }
+    let ret = bjs_createLogger(levelId)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Logger(takingThis: ret)
+}
+
+func getConfigManager() throws(JSException) -> ConfigManager {
+    #if arch(wasm32)
+    @_extern(wasm, module: "Check", name: "bjs_getConfigManager")
+    func bjs_getConfigManager() -> Int32
+    #else
+    func bjs_getConfigManager() -> Int32 {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
+    let ret = bjs_getConfigManager()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return ConfigManager(takingThis: ret)
+}
+
+struct DatabaseConnection {
+    let this: JSObject
+
+    init(this: JSObject) {
+        self.this = this
+    }
+
+    init(takingThis this: Int32) {
+        self.this = JSObject(id: UInt32(bitPattern: this))
+    }
+
+    var isConnected: Bool {
+        get throws(JSException) {
+            #if arch(wasm32)
+            @_extern(wasm, module: "Check", name: "bjs_DatabaseConnection_isConnected_get")
+            func bjs_DatabaseConnection_isConnected_get(_ self: Int32) -> Int32
+            #else
+            func bjs_DatabaseConnection_isConnected_get(_ self: Int32) -> Int32 {
+                fatalError("Only available on WebAssembly")
+            }
+            #endif
+            let ret = bjs_DatabaseConnection_isConnected_get(Int32(bitPattern: self.this.id))
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
+            return ret == 1
+        }
+    }
+
+    var connectionTimeout: Double {
+        get throws(JSException) {
+            #if arch(wasm32)
+            @_extern(wasm, module: "Check", name: "bjs_DatabaseConnection_connectionTimeout_get")
+            func bjs_DatabaseConnection_connectionTimeout_get(_ self: Int32) -> Float64
+            #else
+            func bjs_DatabaseConnection_connectionTimeout_get(_ self: Int32) -> Float64 {
+                fatalError("Only available on WebAssembly")
+            }
+            #endif
+            let ret = bjs_DatabaseConnection_connectionTimeout_get(Int32(bitPattern: self.this.id))
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
+            return Double(ret)
+        }
+    }
+
+    func setConnectionTimeout(_ newValue: Double) throws(JSException) -> Void {
+        #if arch(wasm32)
+        @_extern(wasm, module: "Check", name: "bjs_DatabaseConnection_connectionTimeout_set")
+        func bjs_DatabaseConnection_connectionTimeout_set(_ self: Int32, _ newValue: Float64) -> Void
+        #else
+        func bjs_DatabaseConnection_connectionTimeout_set(_ self: Int32, _ newValue: Float64) -> Void {
+            fatalError("Only available on WebAssembly")
+        }
+        #endif
+        bjs_DatabaseConnection_connectionTimeout_set(Int32(bitPattern: self.this.id), newValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+    }
+
+    func connect(_ url: String) throws(JSException) -> Void {
+        #if arch(wasm32)
+        @_extern(wasm, module: "Check", name: "bjs_DatabaseConnection_connect")
+        func bjs_DatabaseConnection_connect(_ self: Int32, _ url: Int32) -> Void
+        #else
+        func bjs_DatabaseConnection_connect(_ self: Int32, _ url: Int32) -> Void {
+            fatalError("Only available on WebAssembly")
+        }
+        #endif
+        var url = url
+        let urlId = url.withUTF8 { b in
+            _swift_js_make_js_string(b.baseAddress.unsafelyUnwrapped, Int32(b.count))
+        }
+        bjs_DatabaseConnection_connect(Int32(bitPattern: self.this.id), urlId)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+    }
+
+    func execute(_ query: String) throws(JSException) -> JSObject {
+        #if arch(wasm32)
+        @_extern(wasm, module: "Check", name: "bjs_DatabaseConnection_execute")
+        func bjs_DatabaseConnection_execute(_ self: Int32, _ query: Int32) -> Int32
+        #else
+        func bjs_DatabaseConnection_execute(_ self: Int32, _ query: Int32) -> Int32 {
+            fatalError("Only available on WebAssembly")
+        }
+        #endif
+        var query = query
+        let queryId = query.withUTF8 { b in
+            _swift_js_make_js_string(b.baseAddress.unsafelyUnwrapped, Int32(b.count))
+        }
+        let ret = bjs_DatabaseConnection_execute(Int32(bitPattern: self.this.id), queryId)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+        return JSObject(id: UInt32(bitPattern: ret))
+    }
+
+}
+
+struct Logger {
+    let this: JSObject
+
+    init(this: JSObject) {
+        self.this = this
+    }
+
+    init(takingThis this: Int32) {
+        self.this = JSObject(id: UInt32(bitPattern: this))
+    }
+
+    var level: String {
+        get throws(JSException) {
+            #if arch(wasm32)
+            @_extern(wasm, module: "Check", name: "bjs_Logger_level_get")
+            func bjs_Logger_level_get(_ self: Int32) -> Int32
+            #else
+            func bjs_Logger_level_get(_ self: Int32) -> Int32 {
+                fatalError("Only available on WebAssembly")
+            }
+            #endif
+            let ret = bjs_Logger_level_get(Int32(bitPattern: self.this.id))
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
+            return String(unsafeUninitializedCapacity: Int(ret)) { b in
+                _swift_js_init_memory_with_result(b.baseAddress.unsafelyUnwrapped, Int32(ret))
+                return Int(ret)
+            }
+        }
+    }
+
+    func log(_ message: String) throws(JSException) -> Void {
+        #if arch(wasm32)
+        @_extern(wasm, module: "Check", name: "bjs_Logger_log")
+        func bjs_Logger_log(_ self: Int32, _ message: Int32) -> Void
+        #else
+        func bjs_Logger_log(_ self: Int32, _ message: Int32) -> Void {
+            fatalError("Only available on WebAssembly")
+        }
+        #endif
+        var message = message
+        let messageId = message.withUTF8 { b in
+            _swift_js_make_js_string(b.baseAddress.unsafelyUnwrapped, Int32(b.count))
+        }
+        bjs_Logger_log(Int32(bitPattern: self.this.id), messageId)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+    }
+
+    func error(_ message: String, _ error: JSObject) throws(JSException) -> Void {
+        #if arch(wasm32)
+        @_extern(wasm, module: "Check", name: "bjs_Logger_error")
+        func bjs_Logger_error(_ self: Int32, _ message: Int32, _ error: Int32) -> Void
+        #else
+        func bjs_Logger_error(_ self: Int32, _ message: Int32, _ error: Int32) -> Void {
+            fatalError("Only available on WebAssembly")
+        }
+        #endif
+        var message = message
+        let messageId = message.withUTF8 { b in
+            _swift_js_make_js_string(b.baseAddress.unsafelyUnwrapped, Int32(b.count))
+        }
+        bjs_Logger_error(Int32(bitPattern: self.this.id), messageId, Int32(bitPattern: error.id))
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+    }
+
+}
+
+struct ConfigManager {
+    let this: JSObject
+
+    init(this: JSObject) {
+        self.this = this
+    }
+
+    init(takingThis this: Int32) {
+        self.this = JSObject(id: UInt32(bitPattern: this))
+    }
+
+    var configPath: String {
+        get throws(JSException) {
+            #if arch(wasm32)
+            @_extern(wasm, module: "Check", name: "bjs_ConfigManager_configPath_get")
+            func bjs_ConfigManager_configPath_get(_ self: Int32) -> Int32
+            #else
+            func bjs_ConfigManager_configPath_get(_ self: Int32) -> Int32 {
+                fatalError("Only available on WebAssembly")
+            }
+            #endif
+            let ret = bjs_ConfigManager_configPath_get(Int32(bitPattern: self.this.id))
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
+            return String(unsafeUninitializedCapacity: Int(ret)) { b in
+                _swift_js_init_memory_with_result(b.baseAddress.unsafelyUnwrapped, Int32(ret))
+                return Int(ret)
+            }
+        }
+    }
+
+    func get(_ key: String) throws(JSException) -> JSObject {
+        #if arch(wasm32)
+        @_extern(wasm, module: "Check", name: "bjs_ConfigManager_get")
+        func bjs_ConfigManager_get(_ self: Int32, _ key: Int32) -> Int32
+        #else
+        func bjs_ConfigManager_get(_ self: Int32, _ key: Int32) -> Int32 {
+            fatalError("Only available on WebAssembly")
+        }
+        #endif
+        var key = key
+        let keyId = key.withUTF8 { b in
+            _swift_js_make_js_string(b.baseAddress.unsafelyUnwrapped, Int32(b.count))
+        }
+        let ret = bjs_ConfigManager_get(Int32(bitPattern: self.this.id), keyId)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+        return JSObject(id: UInt32(bitPattern: ret))
+    }
+
+    func set(_ key: String, _ value: JSObject) throws(JSException) -> Void {
+        #if arch(wasm32)
+        @_extern(wasm, module: "Check", name: "bjs_ConfigManager_set")
+        func bjs_ConfigManager_set(_ self: Int32, _ key: Int32, _ value: Int32) -> Void
+        #else
+        func bjs_ConfigManager_set(_ self: Int32, _ key: Int32, _ value: Int32) -> Void {
+            fatalError("Only available on WebAssembly")
+        }
+        #endif
+        var key = key
+        let keyId = key.withUTF8 { b in
+            _swift_js_make_js_string(b.baseAddress.unsafelyUnwrapped, Int32(b.count))
+        }
+        bjs_ConfigManager_set(Int32(bitPattern: self.this.id), keyId, Int32(bitPattern: value.id))
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+    }
+
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/TS2SkeletonLike.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/TS2SkeletonLike.swift
@@ -1,0 +1,173 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+@_spi(BridgeJS) import JavaScriptKit
+
+func createTS2Skeleton() throws(JSException) -> TypeScriptProcessor {
+    #if arch(wasm32)
+    @_extern(wasm, module: "Check", name: "bjs_createTS2Skeleton")
+    func bjs_createTS2Skeleton() -> Int32
+    #else
+    func bjs_createTS2Skeleton() -> Int32 {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
+    let ret = bjs_createTS2Skeleton()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return TypeScriptProcessor(takingThis: ret)
+}
+
+func createCodeGenerator(_ format: String) throws(JSException) -> CodeGenerator {
+    #if arch(wasm32)
+    @_extern(wasm, module: "Check", name: "bjs_createCodeGenerator")
+    func bjs_createCodeGenerator(_ format: Int32) -> Int32
+    #else
+    func bjs_createCodeGenerator(_ format: Int32) -> Int32 {
+        fatalError("Only available on WebAssembly")
+    }
+    #endif
+    var format = format
+    let formatId = format.withUTF8 { b in
+        _swift_js_make_js_string(b.baseAddress.unsafelyUnwrapped, Int32(b.count))
+    }
+    let ret = bjs_createCodeGenerator(formatId)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return CodeGenerator(takingThis: ret)
+}
+
+struct TypeScriptProcessor {
+    let this: JSObject
+
+    init(this: JSObject) {
+        self.this = this
+    }
+
+    init(takingThis this: Int32) {
+        self.this = JSObject(id: UInt32(bitPattern: this))
+    }
+
+    var version: String {
+        get throws(JSException) {
+            #if arch(wasm32)
+            @_extern(wasm, module: "Check", name: "bjs_TypeScriptProcessor_version_get")
+            func bjs_TypeScriptProcessor_version_get(_ self: Int32) -> Int32
+            #else
+            func bjs_TypeScriptProcessor_version_get(_ self: Int32) -> Int32 {
+                fatalError("Only available on WebAssembly")
+            }
+            #endif
+            let ret = bjs_TypeScriptProcessor_version_get(Int32(bitPattern: self.this.id))
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
+            return String(unsafeUninitializedCapacity: Int(ret)) { b in
+                _swift_js_init_memory_with_result(b.baseAddress.unsafelyUnwrapped, Int32(ret))
+                return Int(ret)
+            }
+        }
+    }
+
+    func convert(_ ts: String) throws(JSException) -> String {
+        #if arch(wasm32)
+        @_extern(wasm, module: "Check", name: "bjs_TypeScriptProcessor_convert")
+        func bjs_TypeScriptProcessor_convert(_ self: Int32, _ ts: Int32) -> Int32
+        #else
+        func bjs_TypeScriptProcessor_convert(_ self: Int32, _ ts: Int32) -> Int32 {
+            fatalError("Only available on WebAssembly")
+        }
+        #endif
+        var ts = ts
+        let tsId = ts.withUTF8 { b in
+            _swift_js_make_js_string(b.baseAddress.unsafelyUnwrapped, Int32(b.count))
+        }
+        let ret = bjs_TypeScriptProcessor_convert(Int32(bitPattern: self.this.id), tsId)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+        return String(unsafeUninitializedCapacity: Int(ret)) { b in
+            _swift_js_init_memory_with_result(b.baseAddress.unsafelyUnwrapped, Int32(ret))
+            return Int(ret)
+        }
+    }
+
+    func validate(_ ts: String) throws(JSException) -> Bool {
+        #if arch(wasm32)
+        @_extern(wasm, module: "Check", name: "bjs_TypeScriptProcessor_validate")
+        func bjs_TypeScriptProcessor_validate(_ self: Int32, _ ts: Int32) -> Int32
+        #else
+        func bjs_TypeScriptProcessor_validate(_ self: Int32, _ ts: Int32) -> Int32 {
+            fatalError("Only available on WebAssembly")
+        }
+        #endif
+        var ts = ts
+        let tsId = ts.withUTF8 { b in
+            _swift_js_make_js_string(b.baseAddress.unsafelyUnwrapped, Int32(b.count))
+        }
+        let ret = bjs_TypeScriptProcessor_validate(Int32(bitPattern: self.this.id), tsId)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+        return ret == 1
+    }
+
+}
+
+struct CodeGenerator {
+    let this: JSObject
+
+    init(this: JSObject) {
+        self.this = this
+    }
+
+    init(takingThis this: Int32) {
+        self.this = JSObject(id: UInt32(bitPattern: this))
+    }
+
+    var outputFormat: String {
+        get throws(JSException) {
+            #if arch(wasm32)
+            @_extern(wasm, module: "Check", name: "bjs_CodeGenerator_outputFormat_get")
+            func bjs_CodeGenerator_outputFormat_get(_ self: Int32) -> Int32
+            #else
+            func bjs_CodeGenerator_outputFormat_get(_ self: Int32) -> Int32 {
+                fatalError("Only available on WebAssembly")
+            }
+            #endif
+            let ret = bjs_CodeGenerator_outputFormat_get(Int32(bitPattern: self.this.id))
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
+            return String(unsafeUninitializedCapacity: Int(ret)) { b in
+                _swift_js_init_memory_with_result(b.baseAddress.unsafelyUnwrapped, Int32(ret))
+                return Int(ret)
+            }
+        }
+    }
+
+    func generate(_ input: JSObject) throws(JSException) -> String {
+        #if arch(wasm32)
+        @_extern(wasm, module: "Check", name: "bjs_CodeGenerator_generate")
+        func bjs_CodeGenerator_generate(_ self: Int32, _ input: Int32) -> Int32
+        #else
+        func bjs_CodeGenerator_generate(_ self: Int32, _ input: Int32) -> Int32 {
+            fatalError("Only available on WebAssembly")
+        }
+        #endif
+        let ret = bjs_CodeGenerator_generate(Int32(bitPattern: self.this.id), Int32(bitPattern: input.id))
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+        return String(unsafeUninitializedCapacity: Int(ret)) { b in
+            _swift_js_init_memory_with_result(b.baseAddress.unsafelyUnwrapped, Int32(ret))
+            return Int(ret)
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes TypeScript reference errors by generating interface definitions for imported types like TS2Skeleton.