### PR TITLE
BridgeJS: Generate ConvertibleToJSValue extensions for exported Swift classes

### DIFF
--- a/Benchmarks/Sources/Generated/JavaScript/BridgeJS.ExportSwift.json
+++ b/Benchmarks/Sources/Generated/JavaScript/BridgeJS.ExportSwift.json
@@ -19,5 +19,6 @@
         }
       }
     }
-  ]
+  ],
+  "moduleName" : "Benchmarks"
 }

--- a/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/BridgeJS.ExportSwift.swift
+++ b/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/BridgeJS.ExportSwift.swift
@@ -56,6 +56,14 @@ public func _bjs_PlayBridgeJS_deinit(pointer: UnsafeMutableRawPointer) {
     Unmanaged<PlayBridgeJS>.fromOpaque(pointer).release()
 }
 
+extension PlayBridgeJS: ConvertibleToJSValue {
+    var jsValue: JSValue {
+        @_extern(wasm, module: "PlayBridgeJS", name: "bjs_PlayBridgeJS_wrap")
+        func _bjs_PlayBridgeJS_wrap(_: UnsafeMutableRawPointer) -> Int32
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_PlayBridgeJS_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+}
+
 @_expose(wasm, "bjs_PlayBridgeJSOutput_outputJs")
 @_cdecl("bjs_PlayBridgeJSOutput_outputJs")
 public func _bjs_PlayBridgeJSOutput_outputJs(_self: UnsafeMutableRawPointer) -> Void {
@@ -112,4 +120,12 @@ public func _bjs_PlayBridgeJSOutput_exportSwiftGlue(_self: UnsafeMutableRawPoint
 @_cdecl("bjs_PlayBridgeJSOutput_deinit")
 public func _bjs_PlayBridgeJSOutput_deinit(pointer: UnsafeMutableRawPointer) {
     Unmanaged<PlayBridgeJSOutput>.fromOpaque(pointer).release()
+}
+
+extension PlayBridgeJSOutput: ConvertibleToJSValue {
+    var jsValue: JSValue {
+        @_extern(wasm, module: "PlayBridgeJS", name: "bjs_PlayBridgeJSOutput_wrap")
+        func _bjs_PlayBridgeJSOutput_wrap(_: UnsafeMutableRawPointer) -> Int32
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_PlayBridgeJSOutput_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
 }

--- a/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/JavaScript/BridgeJS.ExportSwift.json
+++ b/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/JavaScript/BridgeJS.ExportSwift.json
@@ -120,5 +120,6 @@
   ],
   "functions" : [
 
-  ]
+  ],
+  "moduleName" : "PlayBridgeJS"
 }

--- a/Examples/PlayBridgeJS/Sources/PlayBridgeJS/main.swift
+++ b/Examples/PlayBridgeJS/Sources/PlayBridgeJS/main.swift
@@ -17,7 +17,7 @@ import class Foundation.JSONDecoder
     }
 
     func _update(swiftSource: String, dtsSource: String) throws -> PlayBridgeJSOutput {
-        let exportSwift = ExportSwift(progress: .silent)
+        let exportSwift = ExportSwift(progress: .silent, moduleName: "Playground")
         let sourceFile = Parser.parse(source: swiftSource)
         try exportSwift.addSourceFile(sourceFile, "Playground.swift")
         let exportResult = try exportSwift.finalize()

--- a/Plugins/BridgeJS/Sources/BridgeJSBuildPlugin/BridgeJSBuildPlugin.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSBuildPlugin/BridgeJSBuildPlugin.swift
@@ -42,6 +42,8 @@ struct BridgeJSBuildPlugin: BuildToolPlugin {
             executable: try context.tool(named: "BridgeJSTool").url,
             arguments: [
                 "export",
+                "--module-name",
+                target.name,
                 "--output-skeleton",
                 outputSkeletonPath.path,
                 "--output-swift",

--- a/Plugins/BridgeJS/Sources/BridgeJSCommandPlugin/BridgeJSCommandPlugin.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCommandPlugin/BridgeJSCommandPlugin.swift
@@ -105,6 +105,8 @@ extension BridgeJSCommandPlugin.Context {
         try runBridgeJSTool(
             arguments: [
                 "export",
+                "--module-name",
+                target.name,
                 "--output-skeleton",
                 generatedJavaScriptDirectory.appending(path: "BridgeJS.ExportSwift.json").path,
                 "--output-swift",

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
@@ -55,7 +55,11 @@ public class ExportSwift {
         }
         return (
             outputSwift: outputSwift,
-            outputSkeleton: ExportedSkeleton(moduleName: moduleName, functions: exportedFunctions, classes: exportedClasses)
+            outputSkeleton: ExportedSkeleton(
+                moduleName: moduleName,
+                functions: exportedFunctions,
+                classes: exportedClasses
+            )
         )
     }
 

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -203,6 +203,7 @@ struct BridgeJSLink {
                         bjs["swift_js_release"] = function(id) {
                             swift.memory.release(id);
                         }
+            \(renderSwiftClassWrappers().map { $0.indent(count: 12) }.joined(separator: "\n"))
             \(importObjectBuilders.flatMap { $0.importedLines }.map { $0.indent(count: 12) }.joined(separator: "\n"))
                     },
                     setInstance: (i) => {
@@ -247,6 +248,39 @@ struct BridgeJSLink {
             }>;
             """
         return (outputJs, outputDts)
+    }
+
+    private func renderSwiftClassWrappers() -> [String] {
+        var wrapperLines: [String] = []
+        var modulesByName: [String: [ExportedClass]] = [:]
+        
+        // Group classes by their module name
+        for skeleton in exportedSkeletons {
+            if skeleton.classes.isEmpty { continue }
+            
+            if modulesByName[skeleton.moduleName] == nil {
+                modulesByName[skeleton.moduleName] = []
+            }
+            modulesByName[skeleton.moduleName]?.append(contentsOf: skeleton.classes)
+        }
+        
+        // Generate wrapper functions for each module
+        for (moduleName, classes) in modulesByName {
+            wrapperLines.append("// Wrapper functions for module: \(moduleName)")
+            wrapperLines.append("if (!importObject[\"\(moduleName)\"]) {")
+            wrapperLines.append("    importObject[\"\(moduleName)\"] = {};")
+            wrapperLines.append("}")
+            
+            for klass in classes {
+                let wrapperFunctionName = "bjs_\(klass.name)_wrap"
+                wrapperLines.append("importObject[\"\(moduleName)\"][\"\(wrapperFunctionName)\"] = function(pointer) {")
+                wrapperLines.append("    const obj = \(klass.name).__construct(pointer);")
+                wrapperLines.append("    return swift.memory.retain(obj);")
+                wrapperLines.append("};")
+            }
+        }
+        
+        return wrapperLines
     }
 
     private func generateImportedTypeDefinitions() -> [String] {
@@ -736,7 +770,7 @@ struct BridgeJSLink {
 
         init(moduleName: String) {
             self.moduleName = moduleName
-            importedLines.append("const \(moduleName) = importObject[\"\(moduleName)\"] = {};")
+            importedLines.append("const \(moduleName) = importObject[\"\(moduleName)\"] = importObject[\"\(moduleName)\"] || {};")
         }
 
         func assignToImportObject(name: String, function: [String]) {

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -253,24 +253,24 @@ struct BridgeJSLink {
     private func renderSwiftClassWrappers() -> [String] {
         var wrapperLines: [String] = []
         var modulesByName: [String: [ExportedClass]] = [:]
-        
+
         // Group classes by their module name
         for skeleton in exportedSkeletons {
             if skeleton.classes.isEmpty { continue }
-            
+
             if modulesByName[skeleton.moduleName] == nil {
                 modulesByName[skeleton.moduleName] = []
             }
             modulesByName[skeleton.moduleName]?.append(contentsOf: skeleton.classes)
         }
-        
+
         // Generate wrapper functions for each module
         for (moduleName, classes) in modulesByName {
             wrapperLines.append("// Wrapper functions for module: \(moduleName)")
             wrapperLines.append("if (!importObject[\"\(moduleName)\"]) {")
             wrapperLines.append("    importObject[\"\(moduleName)\"] = {};")
             wrapperLines.append("}")
-            
+
             for klass in classes {
                 let wrapperFunctionName = "bjs_\(klass.name)_wrap"
                 wrapperLines.append("importObject[\"\(moduleName)\"][\"\(wrapperFunctionName)\"] = function(pointer) {")
@@ -279,7 +279,7 @@ struct BridgeJSLink {
                 wrapperLines.append("};")
             }
         }
-        
+
         return wrapperLines
     }
 
@@ -770,7 +770,9 @@ struct BridgeJSLink {
 
         init(moduleName: String) {
             self.moduleName = moduleName
-            importedLines.append("const \(moduleName) = importObject[\"\(moduleName)\"] = importObject[\"\(moduleName)\"] || {};")
+            importedLines.append(
+                "const \(moduleName) = importObject[\"\(moduleName)\"] = importObject[\"\(moduleName)\"] || {};"
+            )
         }
 
         func assignToImportObject(name: String, function: [String]) {

--- a/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
@@ -93,10 +93,12 @@ public struct ExportedConstructor: Codable {
 }
 
 public struct ExportedSkeleton: Codable {
+    public let moduleName: String
     public let functions: [ExportedFunction]
     public let classes: [ExportedClass]
 
-    public init(functions: [ExportedFunction], classes: [ExportedClass]) {
+    public init(moduleName: String, functions: [ExportedFunction], classes: [ExportedClass]) {
+        self.moduleName = moduleName
         self.functions = functions
         self.classes = classes
     }

--- a/Plugins/BridgeJS/Sources/BridgeJSTool/BridgeJSTool.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSTool/BridgeJSTool.swift
@@ -149,6 +149,10 @@ import TS2Skeleton
             let parser = ArgumentParser(
                 singleDashOptions: [:],
                 doubleDashOptions: [
+                    "module-name": OptionRule(
+                        help: "The name of the module for external function references",
+                        required: true
+                    ),
                     "output-skeleton": OptionRule(
                         help: "The output file path for the skeleton of the exported Swift APIs",
                         required: true
@@ -168,7 +172,7 @@ import TS2Skeleton
                 arguments: Array(arguments.dropFirst())
             )
             let progress = ProgressReporting(verbose: doubleDashOptions["verbose"] == "true")
-            let exporter = ExportSwift(progress: progress)
+            let exporter = ExportSwift(progress: progress, moduleName: doubleDashOptions["module-name"]!)
             for inputFile in positionalArguments.sorted() {
                 let sourceURL = URL(fileURLWithPath: inputFile)
                 guard sourceURL.pathExtension == "swift" else { continue }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/BridgeJSLinkTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/BridgeJSLinkTests.swift
@@ -46,7 +46,7 @@ import Testing
     func snapshotExport(input: String) throws {
         let url = Self.inputsDirectory.appendingPathComponent(input)
         let sourceFile = Parser.parse(source: try String(contentsOf: url, encoding: .utf8))
-        let swiftAPI = ExportSwift(progress: .silent)
+        let swiftAPI = ExportSwift(progress: .silent, moduleName: "TestModule")
         try swiftAPI.addSourceFile(sourceFile, input)
         let name = url.deletingPathExtension().lastPathComponent
 

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/ExportSwiftTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/ExportSwiftTests.swift
@@ -47,7 +47,7 @@ import Testing
 
     @Test(arguments: collectInputs())
     func snapshot(input: String) throws {
-        let swiftAPI = ExportSwift(progress: .silent)
+        let swiftAPI = ExportSwift(progress: .silent, moduleName: "TestModule")
         let url = Self.inputsDirectory.appendingPathComponent(input)
         let sourceFile = Parser.parse(source: try String(contentsOf: url, encoding: .utf8))
         try swiftAPI.addSourceFile(sourceFile, input)

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayParameter.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayParameter.Import.js
@@ -46,7 +46,8 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
             }
-            const TestModule = importObject["TestModule"] = {};
+
+            const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_checkArray"] = function bjs_checkArray(a) {
                 try {
                     options.imports.checkArray(swift.memory.getObject(a));

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Interface.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Interface.Import.js
@@ -46,7 +46,8 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
             }
-            const TestModule = importObject["TestModule"] = {};
+
+            const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_returnAnimatable"] = function bjs_returnAnimatable() {
                 try {
                     let ret = options.imports.returnAnimatable();

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MultipleImportedTypes.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MultipleImportedTypes.Import.js
@@ -46,7 +46,8 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
             }
-            const TestModule = importObject["TestModule"] = {};
+
+            const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_createDatabaseConnection"] = function bjs_createDatabaseConnection(config) {
                 try {
                     let ret = options.imports.createDatabaseConnection(swift.memory.getObject(config));

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Export.js
@@ -46,6 +46,22 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
             }
+            // Wrapper functions for module: TestModule
+            if (!importObject["TestModule"]) {
+                importObject["TestModule"] = {};
+            }
+            importObject["TestModule"]["bjs_Greeter_wrap"] = function(pointer) {
+                const obj = Greeter.__construct(pointer);
+                return swift.memory.retain(obj);
+            };
+            importObject["TestModule"]["bjs_Converter_wrap"] = function(pointer) {
+                const obj = Converter.__construct(pointer);
+                return swift.memory.retain(obj);
+            };
+            importObject["TestModule"]["bjs_UUID_wrap"] = function(pointer) {
+                const obj = UUID.__construct(pointer);
+                return swift.memory.retain(obj);
+            };
 
         },
         setInstance: (i) => {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.Export.js
@@ -47,6 +47,7 @@ export async function createInstantiator(options, swift) {
                 swift.memory.release(id);
             }
 
+
         },
         setInstance: (i) => {
             instance = i;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.Import.js
@@ -46,7 +46,8 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
             }
-            const TestModule = importObject["TestModule"] = {};
+
+            const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_check"] = function bjs_check(a, b) {
                 try {
                     options.imports.check(a, b);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.Export.js
@@ -47,6 +47,7 @@ export async function createInstantiator(options, swift) {
                 swift.memory.release(id);
             }
 
+
         },
         setInstance: (i) => {
             instance = i;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.Import.js
@@ -46,7 +46,8 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
             }
-            const TestModule = importObject["TestModule"] = {};
+
+            const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_checkNumber"] = function bjs_checkNumber() {
                 try {
                     let ret = options.imports.checkNumber();

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.Export.js
@@ -47,6 +47,7 @@ export async function createInstantiator(options, swift) {
                 swift.memory.release(id);
             }
 
+
         },
         setInstance: (i) => {
             instance = i;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.Import.js
@@ -46,7 +46,8 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
             }
-            const TestModule = importObject["TestModule"] = {};
+
+            const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_checkString"] = function bjs_checkString(a) {
                 try {
                     const aObject = swift.memory.getObject(a);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.Export.js
@@ -47,6 +47,7 @@ export async function createInstantiator(options, swift) {
                 swift.memory.release(id);
             }
 
+
         },
         setInstance: (i) => {
             instance = i;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.Import.js
@@ -46,7 +46,8 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
             }
-            const TestModule = importObject["TestModule"] = {};
+
+            const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_checkString"] = function bjs_checkString() {
                 try {
                     let ret = options.imports.checkString();

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.Export.js
@@ -46,6 +46,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
             }
+            // Wrapper functions for module: TestModule
+            if (!importObject["TestModule"]) {
+                importObject["TestModule"] = {};
+            }
+            importObject["TestModule"]["bjs_Greeter_wrap"] = function(pointer) {
+                const obj = Greeter.__construct(pointer);
+                return swift.memory.retain(obj);
+            };
 
         },
         setInstance: (i) => {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TS2SkeletonLike.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TS2SkeletonLike.Import.js
@@ -46,7 +46,8 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
             }
-            const TestModule = importObject["TestModule"] = {};
+
+            const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_createTS2Skeleton"] = function bjs_createTS2Skeleton() {
                 try {
                     let ret = options.imports.createTS2Skeleton();

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.Export.js
@@ -47,6 +47,7 @@ export async function createInstantiator(options, swift) {
                 swift.memory.release(id);
             }
 
+
         },
         setInstance: (i) => {
             instance = i;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TypeAlias.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TypeAlias.Import.js
@@ -46,7 +46,8 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
             }
-            const TestModule = importObject["TestModule"] = {};
+
+            const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_checkSimple"] = function bjs_checkSimple(a) {
                 try {
                     options.imports.checkSimple(a);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TypeScriptClass.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TypeScriptClass.Import.js
@@ -46,7 +46,8 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
             }
-            const TestModule = importObject["TestModule"] = {};
+
+            const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_Greeter_init"] = function bjs_Greeter_init(name) {
                 try {
                     const nameObject = swift.memory.getObject(name);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.Export.js
@@ -47,6 +47,7 @@ export async function createInstantiator(options, swift) {
                 swift.memory.release(id);
             }
 
+
         },
         setInstance: (i) => {
             instance = i;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.Import.js
@@ -46,7 +46,8 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
             }
-            const TestModule = importObject["TestModule"] = {};
+
+            const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_check"] = function bjs_check() {
                 try {
                     options.imports.check();

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Namespaces.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Namespaces.json
@@ -149,5 +149,6 @@
         }
       }
     }
-  ]
+  ],
+  "moduleName" : "TestModule"
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Namespaces.swift.actual
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Namespaces.swift.actual
@@ -68,9 +68,9 @@ public func _bjs_Greeter_deinit(pointer: UnsafeMutableRawPointer) {
 
 extension Greeter: ConvertibleToJSValue {
     var jsValue: JSValue {
-        @_extern(wasm, module: "TestModule", name: "bjs_Greeter_wrap")
+        @_extern(wasm, module: "JavaScriptKit", name: "bjs_Greeter_wrap")
         func _bjs_Greeter_wrap(_: UnsafeMutableRawPointer) -> Int32
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Greeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return JSObject(id: UInt32(bitPattern: _bjs_Greeter_wrap(Unmanaged.passRetained(self).toOpaque())))
     }
 }
 
@@ -106,9 +106,9 @@ public func _bjs_Converter_deinit(pointer: UnsafeMutableRawPointer) {
 
 extension Converter: ConvertibleToJSValue {
     var jsValue: JSValue {
-        @_extern(wasm, module: "TestModule", name: "bjs_Converter_wrap")
+        @_extern(wasm, module: "JavaScriptKit", name: "bjs_Converter_wrap")
         func _bjs_Converter_wrap(_: UnsafeMutableRawPointer) -> Int32
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Converter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return JSObject(id: UInt32(bitPattern: _bjs_Converter_wrap(Unmanaged.passRetained(self).toOpaque())))
     }
 }
 
@@ -133,8 +133,8 @@ public func _bjs_UUID_deinit(pointer: UnsafeMutableRawPointer) {
 
 extension UUID: ConvertibleToJSValue {
     var jsValue: JSValue {
-        @_extern(wasm, module: "TestModule", name: "bjs_UUID_wrap")
+        @_extern(wasm, module: "JavaScriptKit", name: "bjs_UUID_wrap")
         func _bjs_UUID_wrap(_: UnsafeMutableRawPointer) -> Int32
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_UUID_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return JSObject(id: UInt32(bitPattern: _bjs_UUID_wrap(Unmanaged.passRetained(self).toOpaque())))
     }
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/PrimitiveParameters.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/PrimitiveParameters.json
@@ -54,5 +54,6 @@
         }
       }
     }
-  ]
+  ],
+  "moduleName" : "TestModule"
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/PrimitiveReturn.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/PrimitiveReturn.json
@@ -67,5 +67,6 @@
         }
       }
     }
-  ]
+  ],
+  "moduleName" : "TestModule"
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StringParameter.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StringParameter.json
@@ -27,5 +27,6 @@
         }
       }
     }
-  ]
+  ],
+  "moduleName" : "TestModule"
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StringReturn.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StringReturn.json
@@ -19,5 +19,6 @@
         }
       }
     }
-  ]
+  ],
+  "moduleName" : "TestModule"
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/SwiftClass.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/SwiftClass.json
@@ -89,5 +89,6 @@
         }
       }
     }
-  ]
+  ],
+  "moduleName" : "TestModule"
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/SwiftClass.swift.actual
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/SwiftClass.swift.actual
@@ -66,8 +66,8 @@ public func _bjs_Greeter_deinit(pointer: UnsafeMutableRawPointer) {
 
 extension Greeter: ConvertibleToJSValue {
     var jsValue: JSValue {
-        @_extern(wasm, module: "TestModule", name: "bjs_Greeter_wrap")
+        @_extern(wasm, module: "JavaScriptKit", name: "bjs_Greeter_wrap")
         func _bjs_Greeter_wrap(_: UnsafeMutableRawPointer) -> Int32
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Greeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return JSObject(id: UInt32(bitPattern: _bjs_Greeter_wrap(Unmanaged.passRetained(self).toOpaque())))
     }
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Throws.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Throws.json
@@ -19,5 +19,6 @@
         }
       }
     }
-  ]
+  ],
+  "moduleName" : "TestModule"
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/VoidParameterVoidReturn.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/VoidParameterVoidReturn.json
@@ -19,5 +19,6 @@
         }
       }
     }
-  ]
+  ],
+  "moduleName" : "TestModule"
 }

--- a/Plugins/PackageToJS/Tests/ExampleTests.swift
+++ b/Plugins/PackageToJS/Tests/ExampleTests.swift
@@ -255,7 +255,10 @@ extension Trait where Self == ConditionTrait {
                 try scriptContent.write(to: tempDir.appending(path: "script.js"), atomically: true, encoding: .utf8)
                 let scriptPath = tempDir.appending(path: "script.js")
                 try runSwift(
-                    ["package", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test", "-Xnode=--require=\(scriptPath.path)"],
+                    [
+                        "package", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test",
+                        "-Xnode=--require=\(scriptPath.path)",
+                    ],
                     [:]
                 )
                 let testPath = tempDir.appending(path: "test.txt")
@@ -265,7 +268,10 @@ extension Trait where Self == ConditionTrait {
                     "test.txt should be created by the script"
                 )
             })
-            try runSwift(["package", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test", "--environment", "browser"], [:])
+            try runSwift(
+                ["package", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test", "--environment", "browser"],
+                [:]
+            )
         }
     }
 

--- a/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
+++ b/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
@@ -99,6 +99,20 @@ struct TestError: Error {
     return calc.add(a: calc.square(value: x), b: y)
 }
 
+@JS func testGreeterToJSValue() -> JSObject {
+    let greeter = Greeter(name: "Test")
+    return greeter.jsValue.object!
+}
+
+@JS func testCalculatorToJSValue() -> JSObject {
+    let calc = Calculator()
+    return calc.jsValue.object!
+}
+
+@JS func testSwiftClassAsJSValue(greeter: Greeter) -> JSObject {
+    return greeter.jsValue.object!
+}
+
 class ExportAPITests: XCTestCase {
     func testAll() {
         var hasDeinitGreeter = false

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.ExportSwift.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.ExportSwift.json
@@ -537,6 +537,63 @@
 
         }
       }
+    },
+    {
+      "abiName" : "bjs_testGreeterToJSValue",
+      "effects" : {
+        "isAsync" : false,
+        "isThrows" : false
+      },
+      "name" : "testGreeterToJSValue",
+      "parameters" : [
+
+      ],
+      "returnType" : {
+        "jsObject" : {
+
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_testCalculatorToJSValue",
+      "effects" : {
+        "isAsync" : false,
+        "isThrows" : false
+      },
+      "name" : "testCalculatorToJSValue",
+      "parameters" : [
+
+      ],
+      "returnType" : {
+        "jsObject" : {
+
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_testSwiftClassAsJSValue",
+      "effects" : {
+        "isAsync" : false,
+        "isThrows" : false
+      },
+      "name" : "testSwiftClassAsJSValue",
+      "parameters" : [
+        {
+          "label" : "greeter",
+          "name" : "greeter",
+          "type" : {
+            "swiftHeapObject" : {
+              "_0" : "Greeter"
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "jsObject" : {
+
+        }
+      }
     }
-  ]
+  ],
+  "moduleName" : "BridgeJSRuntimeTests"
 }


### PR DESCRIPTION
@JS classes now automatically support conversion to JSValue, enabling seamless interoperability between Swift and JavaScript.