### PR TITLE
Fix Package.swift warning by excluding JavaScript files

### DIFF
--- a/Plugins/BridgeJS/Package.swift
+++ b/Plugins/BridgeJS/Package.swift
@@ -22,7 +22,8 @@ let package = Package(
             dependencies: [
                 "BridgeJSCore",
                 "BridgeJSSkeleton",
-            ]
+            ],
+            exclude: ["JavaScript"]
         ),
         .target(
             name: "BridgeJSCore",


### PR DESCRIPTION
Exclude JavaScript directory from TS2Skeleton target to resolve Swift package warning.