### PR TITLE
enable using JavaScriptKit with packages that have macros that use SwiftSyntax 601

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .plugin(name: "BridgeJSCommandPlugin", targets: ["BridgeJSCommandPlugin"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-syntax", "600.0.0"..<"601.0.0")
+        .package(url: "https://github.com/swiftlang/swift-syntax", "600.0.0" ..< "602.0.0")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .plugin(name: "BridgeJSCommandPlugin", targets: ["BridgeJSCommandPlugin"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-syntax", "600.0.0" ..< "602.0.0")
+        .package(url: "https://github.com/swiftlang/swift-syntax", "600.0.0"..<"602.0.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
enable using JavaScriptKit with packages that have macros that use SwiftSyntax 601

this is a very annoying limitation, that effectively makes entire build trees incompatible with certain macro packages