### PR TITLE
BridgeJS: Fix nested type resolution for MemberTypeSyntax (e.g., Networking.API.Method)

### DIFF
--- a/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
+++ b/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
@@ -223,6 +223,8 @@ struct TestError: Error {
     return .light
 }
 
+// MARK: - Namespace Enums
+
 @JS enum Utils {
     @JS class Converter {
         @JS init() {}
@@ -273,6 +275,31 @@ enum Internal {
         @JS init() {}
         @JS func call(_ method: SupportedMethod) {}
     }
+}
+
+@JS func echoNetworkingAPIMethod(_ method: Networking.API.Method) -> Networking.API.Method {
+    return method
+}
+
+@JS func echoConfigurationLogLevel(_ level: Configuration.LogLevel) -> Configuration.LogLevel {
+    return level
+}
+
+@JS func echoConfigurationPort(_ port: Configuration.Port) -> Configuration.Port {
+    return port
+}
+
+@JS func processConfigurationLogLevel(_ level: Configuration.LogLevel) -> Configuration.Port {
+    switch level {
+    case .debug: return .development
+    case .info: return .http
+    case .warning: return .https
+    case .error: return .development
+    }
+}
+
+@JS func echoInternalSupportedMethod(_ method: Internal.SupportedMethod) -> Internal.SupportedMethod {
+    return method
 }
 
 // MARK: - Property Tests

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.ExportSwift.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.ExportSwift.swift
@@ -814,6 +814,61 @@ public func _bjs_getTSTheme() -> Void {
     #endif
 }
 
+@_expose(wasm, "bjs_echoNetworkingAPIMethod")
+@_cdecl("bjs_echoNetworkingAPIMethod")
+public func _bjs_echoNetworkingAPIMethod(method: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = echoNetworkingAPIMethod(_: Networking.API.Method.bridgeJSLiftParameter(method))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_echoConfigurationLogLevel")
+@_cdecl("bjs_echoConfigurationLogLevel")
+public func _bjs_echoConfigurationLogLevel(levelBytes: Int32, levelLength: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = echoConfigurationLogLevel(_: Configuration.LogLevel.bridgeJSLiftParameter(levelBytes, levelLength))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_echoConfigurationPort")
+@_cdecl("bjs_echoConfigurationPort")
+public func _bjs_echoConfigurationPort(port: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = echoConfigurationPort(_: Configuration.Port.bridgeJSLiftParameter(port))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_processConfigurationLogLevel")
+@_cdecl("bjs_processConfigurationLogLevel")
+public func _bjs_processConfigurationLogLevel(levelBytes: Int32, levelLength: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = processConfigurationLogLevel(_: Configuration.LogLevel.bridgeJSLiftParameter(levelBytes, levelLength))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_echoInternalSupportedMethod")
+@_cdecl("bjs_echoInternalSupportedMethod")
+public func _bjs_echoInternalSupportedMethod(method: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = echoInternalSupportedMethod(_: Internal.SupportedMethod.bridgeJSLiftParameter(method))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs_createPropertyHolder")
 @_cdecl("bjs_createPropertyHolder")
 public func _bjs_createPropertyHolder(intValue: Int32, floatValue: Float32, doubleValue: Float64, boolValue: Int32, stringValueBytes: Int32, stringValueLength: Int32, jsObject: Int32) -> UnsafeMutableRawPointer {

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.ExportSwift.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.ExportSwift.json
@@ -1827,6 +1827,132 @@
       }
     },
     {
+      "abiName" : "bjs_echoNetworkingAPIMethod",
+      "effects" : {
+        "isAsync" : false,
+        "isThrows" : false
+      },
+      "name" : "echoNetworkingAPIMethod",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "method",
+          "type" : {
+            "caseEnum" : {
+              "_0" : "Networking.API.Method"
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "caseEnum" : {
+          "_0" : "Networking.API.Method"
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_echoConfigurationLogLevel",
+      "effects" : {
+        "isAsync" : false,
+        "isThrows" : false
+      },
+      "name" : "echoConfigurationLogLevel",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "level",
+          "type" : {
+            "rawValueEnum" : {
+              "_0" : "Configuration.LogLevel",
+              "_1" : "String"
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "rawValueEnum" : {
+          "_0" : "Configuration.LogLevel",
+          "_1" : "String"
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_echoConfigurationPort",
+      "effects" : {
+        "isAsync" : false,
+        "isThrows" : false
+      },
+      "name" : "echoConfigurationPort",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "port",
+          "type" : {
+            "rawValueEnum" : {
+              "_0" : "Configuration.Port",
+              "_1" : "Int"
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "rawValueEnum" : {
+          "_0" : "Configuration.Port",
+          "_1" : "Int"
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_processConfigurationLogLevel",
+      "effects" : {
+        "isAsync" : false,
+        "isThrows" : false
+      },
+      "name" : "processConfigurationLogLevel",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "level",
+          "type" : {
+            "rawValueEnum" : {
+              "_0" : "Configuration.LogLevel",
+              "_1" : "String"
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "rawValueEnum" : {
+          "_0" : "Configuration.Port",
+          "_1" : "Int"
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_echoInternalSupportedMethod",
+      "effects" : {
+        "isAsync" : false,
+        "isThrows" : false
+      },
+      "name" : "echoInternalSupportedMethod",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "method",
+          "type" : {
+            "caseEnum" : {
+              "_0" : "Internal.SupportedMethod"
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "caseEnum" : {
+          "_0" : "Internal.SupportedMethod"
+        }
+      }
+    },
+    {
       "abiName" : "bjs_createPropertyHolder",
       "effects" : {
         "isAsync" : false,

--- a/Tests/prelude.mjs
+++ b/Tests/prelude.mjs
@@ -354,6 +354,15 @@ function BridgeJSRuntimeTests_runJsWorks(instance, exports) {
     assert.equal(globalThis.Networking.APIV2.Internal.SupportedMethod.Get, 0);
     assert.equal(globalThis.Networking.APIV2.Internal.SupportedMethod.Post, 1);
 
+    assert.equal(exports.echoNetworkingAPIMethod(globalThis.Networking.API.Method.Get), globalThis.Networking.API.Method.Get);
+    assert.equal(exports.echoConfigurationLogLevel(globalThis.Configuration.LogLevel.Debug), globalThis.Configuration.LogLevel.Debug);
+    assert.equal(exports.echoConfigurationPort(globalThis.Configuration.Port.Http), globalThis.Configuration.Port.Http);
+    assert.equal(exports.processConfigurationLogLevel(globalThis.Configuration.LogLevel.Debug), globalThis.Configuration.Port.Development);
+    assert.equal(exports.processConfigurationLogLevel(globalThis.Configuration.LogLevel.Info), globalThis.Configuration.Port.Http);
+    assert.equal(exports.processConfigurationLogLevel(globalThis.Configuration.LogLevel.Warning), globalThis.Configuration.Port.Https);
+    assert.equal(exports.processConfigurationLogLevel(globalThis.Configuration.LogLevel.Error), globalThis.Configuration.Port.Development);
+    assert.equal(exports.echoInternalSupportedMethod(globalThis.Networking.APIV2.Internal.SupportedMethod.Get), globalThis.Networking.APIV2.Internal.SupportedMethod.Get);
+
     const converter = new exports.Converter();
     assert.equal(converter.toString(42), "42");
     assert.equal(converter.toString(123), "123");


### PR DESCRIPTION
## Issue 
Currently for functions that would be using nested types like:

```swift
@JS func echoNetworkingAPIMethod(_ method: Networking.API.Method) -> Networking.API.Method { … }
```

We'd get following error:
```swift
error: Unsupported type: Networking.API.Method
Hint: Only primitive types and types defined in the same module are allowed
```

Issue is that currently `lookupType(for` only handles `IdentifierTypeSyntax`, hence `MemberTypeSyntax` like `Networking.API.Method` would not be resolved to a valid declaration.
 
## Fix
Centralized type resolution in `TypeDeclResolver` with a new `resolve(_: TypeSyntax)` API and used it in `ExportSwift` to map nested enums/classes/actors to `BridgeType`. This should help with nested types resolution, while exported ABI remains unchanged for already-supported types.
New tests were added to `prelude.mjs` to confirm the fix.