### PR TITLE
[NFC] BridgeJS: Migrate to code fragment printer

### DIFF
--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayParameter.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayParameter.Import.js
@@ -21,7 +21,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -84,7 +83,6 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_param_f64"] = function() {
                 return tmpParamF64s.pop();
             }
-
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_checkArray"] = function bjs_checkArray(a) {
                 try {
@@ -111,7 +109,7 @@ export async function createInstantiator(options, swift) {
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -119,9 +117,7 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-
             return {
-
             };
         },
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.Export.js
@@ -21,7 +21,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -84,13 +83,11 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_param_f64"] = function() {
                 return tmpParamF64s.pop();
             }
-
-
         },
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -98,7 +95,6 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-
             return {
                 asyncReturnVoid: function bjs_asyncReturnVoid() {
                     const ret = instance.exports.bjs_asyncReturnVoid();

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.Import.js
@@ -21,7 +21,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -84,7 +83,6 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_param_f64"] = function() {
                 return tmpParamF64s.pop();
             }
-
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_asyncReturnVoid"] = function bjs_asyncReturnVoid() {
                 try {
@@ -155,7 +153,7 @@ export async function createInstantiator(options, swift) {
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -163,9 +161,7 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-
             return {
-
             };
         },
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.Export.js
@@ -342,7 +342,6 @@ const __bjs_createNetworkingResultHelpers = () => {
         }
     });
 };
-
 if (typeof globalThis.Utilities === 'undefined') {
     globalThis.Utilities = {};
 }
@@ -433,13 +432,10 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_param_f64"] = function() {
                 return tmpParamF64s.pop();
             }
-
-
         },
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
 
             const APIResultHelpers = __bjs_createAPIResultHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, textEncoder, swift);
             enumHelpers.APIResult = APIResultHelpers;
@@ -460,7 +456,6 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-
             return {
                 handle: function bjs_handle(result) {
                     const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.APIResult.lower(result);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCase.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCase.Export.js
@@ -28,7 +28,6 @@ export const PublicStatus = {
     Success: 0,
 };
 
-
 export async function createInstantiator(options, swift) {
     let instance;
     let memory;
@@ -46,7 +45,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -109,13 +107,11 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_param_f64"] = function() {
                 return tmpParamF64s.pop();
             }
-
-
         },
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -123,7 +119,6 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-
             return {
                 setDirection: function bjs_setDirection(direction) {
                     instance.exports.bjs_setDirection(direction);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Export.js
@@ -29,7 +29,6 @@ export const SupportedMethod = {
     Post: 1,
 };
 
-
 if (typeof globalThis.Networking === 'undefined') {
     globalThis.Networking = {};
 }
@@ -68,7 +67,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -147,12 +145,11 @@ export async function createInstantiator(options, swift) {
                 const obj = TestServer.__construct(pointer);
                 return swift.memory.retain(obj);
             };
-
         },
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -183,8 +180,7 @@ export async function createInstantiator(options, swift) {
                 static __construct(ptr) {
                     return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Converter_deinit, Converter.prototype);
                 }
-                
-                
+            
                 constructor() {
                     const ret = instance.exports.bjs_Converter_init();
                     return Converter.__construct(ret);
@@ -200,8 +196,7 @@ export async function createInstantiator(options, swift) {
                 static __construct(ptr) {
                     return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_HTTPServer_deinit, HTTPServer.prototype);
                 }
-                
-                
+            
                 constructor() {
                     const ret = instance.exports.bjs_HTTPServer_init();
                     return HTTPServer.__construct(ret);
@@ -214,8 +209,7 @@ export async function createInstantiator(options, swift) {
                 static __construct(ptr) {
                     return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestServer_deinit, TestServer.prototype);
                 }
-                
-                
+            
                 constructor() {
                     const ret = instance.exports.bjs_TestServer_init();
                     return TestServer.__construct(ret);
@@ -229,7 +223,6 @@ export async function createInstantiator(options, swift) {
                 HTTPServer,
                 TestServer,
             };
-
             if (typeof globalThis.Networking === 'undefined') {
                 globalThis.Networking = {};
             }
@@ -248,7 +241,6 @@ export async function createInstantiator(options, swift) {
             globalThis.Utils.Converter = exports.Converter;
             globalThis.Networking.API.HTTPServer = exports.HTTPServer;
             globalThis.Networking.APIV2.Internal.TestServer = exports.TestServer;
-
             return exports;
         },
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumRawType.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumRawType.Export.js
@@ -79,7 +79,6 @@ export const Ratio = {
     Pi: 3.14159,
 };
 
-
 export async function createInstantiator(options, swift) {
     let instance;
     let memory;
@@ -97,7 +96,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -160,13 +158,11 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_param_f64"] = function() {
                 return tmpParamF64s.pop();
             }
-
-
         },
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -174,7 +170,6 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-
             return {
                 setTheme: function bjs_setTheme(theme) {
                     const themeBytes = textEncoder.encode(theme);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Interface.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Interface.Import.js
@@ -21,7 +21,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -84,7 +83,6 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_param_f64"] = function() {
                 return tmpParamF64s.pop();
             }
-
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_returnAnimatable"] = function bjs_returnAnimatable() {
                 try {
@@ -117,7 +115,7 @@ export async function createInstantiator(options, swift) {
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -125,9 +123,7 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-
             return {
-
             };
         },
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/InvalidPropertyNames.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/InvalidPropertyNames.Import.js
@@ -21,7 +21,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -84,7 +83,6 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_param_f64"] = function() {
                 return tmpParamF64s.pop();
             }
-
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_createArrayBuffer"] = function bjs_createArrayBuffer() {
                 try {
@@ -187,7 +185,7 @@ export async function createInstantiator(options, swift) {
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -195,9 +193,7 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-
             return {
-
             };
         },
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MultipleImportedTypes.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MultipleImportedTypes.Import.js
@@ -21,7 +21,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -84,7 +83,6 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_param_f64"] = function() {
                 return tmpParamF64s.pop();
             }
-
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_createDatabaseConnection"] = function bjs_createDatabaseConnection(config) {
                 try {
@@ -221,7 +219,7 @@ export async function createInstantiator(options, swift) {
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -229,9 +227,7 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-
             return {
-
             };
         },
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Export.js
@@ -21,7 +21,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -100,12 +99,11 @@ export async function createInstantiator(options, swift) {
                 const obj = UUID.__construct(pointer);
                 return swift.memory.retain(obj);
             };
-
         },
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -136,8 +134,7 @@ export async function createInstantiator(options, swift) {
                 static __construct(ptr) {
                     return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Greeter_deinit, Greeter.prototype);
                 }
-                
-                
+            
                 constructor(name) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
@@ -156,8 +153,7 @@ export async function createInstantiator(options, swift) {
                 static __construct(ptr) {
                     return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Converter_deinit, Converter.prototype);
                 }
-                
-                
+            
                 constructor() {
                     const ret = instance.exports.bjs_Converter_init();
                     return Converter.__construct(ret);
@@ -173,7 +169,7 @@ export async function createInstantiator(options, swift) {
                 static __construct(ptr) {
                     return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_UUID_deinit, UUID.prototype);
                 }
-                
+            
                 uuidString() {
                     instance.exports.bjs_UUID_uuidString(this.pointer);
                     const ret = tmpRetString;
@@ -198,7 +194,6 @@ export async function createInstantiator(options, swift) {
                     return ret;
                 },
             };
-
             if (typeof globalThis.MyModule === 'undefined') {
                 globalThis.MyModule = {};
             }
@@ -221,7 +216,6 @@ export async function createInstantiator(options, swift) {
             globalThis.Utils.Converters.Converter = exports.Converter;
             globalThis.__Swift.Foundation.UUID = exports.UUID;
             globalThis.MyModule.Utils.namespacedFunction = exports.namespacedFunction;
-
             return exports;
         },
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.Export.js
@@ -21,7 +21,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -84,13 +83,11 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_param_f64"] = function() {
                 return tmpParamF64s.pop();
             }
-
-
         },
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -98,7 +95,6 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-
             return {
                 check: function bjs_check(a, b, c, d) {
                     instance.exports.bjs_check(a, b, c, d);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.Import.js
@@ -21,7 +21,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -84,7 +83,6 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_param_f64"] = function() {
                 return tmpParamF64s.pop();
             }
-
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_check"] = function bjs_check(a, b) {
                 try {
@@ -97,7 +95,7 @@ export async function createInstantiator(options, swift) {
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -105,9 +103,7 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-
             return {
-
             };
         },
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.Export.js
@@ -21,7 +21,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -84,13 +83,11 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_param_f64"] = function() {
                 return tmpParamF64s.pop();
             }
-
-
         },
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -98,7 +95,6 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-
             return {
                 checkInt: function bjs_checkInt() {
                     const ret = instance.exports.bjs_checkInt();

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.Import.js
@@ -21,7 +21,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -84,7 +83,6 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_param_f64"] = function() {
                 return tmpParamF64s.pop();
             }
-
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_checkNumber"] = function bjs_checkNumber() {
                 try {
@@ -108,7 +106,7 @@ export async function createInstantiator(options, swift) {
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -116,9 +114,7 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-
             return {
-
             };
         },
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PropertyTypes.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PropertyTypes.Export.js
@@ -21,7 +21,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -92,12 +91,11 @@ export async function createInstantiator(options, swift) {
                 const obj = PropertyHolder.__construct(pointer);
                 return swift.memory.retain(obj);
             };
-
         },
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -128,8 +126,7 @@ export async function createInstantiator(options, swift) {
                 static __construct(ptr) {
                     return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_PropertyHolder_deinit, PropertyHolder.prototype);
                 }
-                
-                
+            
                 constructor(intValue, floatValue, doubleValue, boolValue, stringValue, jsObject) {
                     const stringValueBytes = textEncoder.encode(stringValue);
                     const stringValueId = swift.memory.retain(stringValueBytes);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.Export.js
@@ -21,7 +21,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -84,13 +83,11 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_param_f64"] = function() {
                 return tmpParamF64s.pop();
             }
-
-
         },
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -98,7 +95,6 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-
             return {
                 checkString: function bjs_checkString(a) {
                     const aBytes = textEncoder.encode(a);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.Import.js
@@ -21,7 +21,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -84,7 +83,6 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_param_f64"] = function() {
                 return tmpParamF64s.pop();
             }
-
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_checkString"] = function bjs_checkString(a) {
                 try {
@@ -108,7 +106,7 @@ export async function createInstantiator(options, swift) {
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -116,9 +114,7 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-
             return {
-
             };
         },
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.Export.js
@@ -21,7 +21,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -84,13 +83,11 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_param_f64"] = function() {
                 return tmpParamF64s.pop();
             }
-
-
         },
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -98,7 +95,6 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-
             return {
                 checkString: function bjs_checkString() {
                     instance.exports.bjs_checkString();

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.Import.js
@@ -21,7 +21,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -84,7 +83,6 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_param_f64"] = function() {
                 return tmpParamF64s.pop();
             }
-
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_checkString"] = function bjs_checkString() {
                 try {
@@ -99,7 +97,7 @@ export async function createInstantiator(options, swift) {
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -107,9 +105,7 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-
             return {
-
             };
         },
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.Export.js
@@ -21,7 +21,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -100,12 +99,11 @@ export async function createInstantiator(options, swift) {
                 const obj = PackageGreeter.__construct(pointer);
                 return swift.memory.retain(obj);
             };
-
         },
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -136,8 +134,7 @@ export async function createInstantiator(options, swift) {
                 static __construct(ptr) {
                     return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Greeter_deinit, Greeter.prototype);
                 }
-                
-                
+            
                 constructor(name) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
@@ -174,13 +171,13 @@ export async function createInstantiator(options, swift) {
                 static __construct(ptr) {
                     return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_PublicGreeter_deinit, PublicGreeter.prototype);
                 }
-                
+            
             }
             class PackageGreeter extends SwiftHeapObject {
                 static __construct(ptr) {
                     return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_PackageGreeter_deinit, PackageGreeter.prototype);
                 }
-                
+            
             }
             return {
                 Greeter,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TS2SkeletonLike.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TS2SkeletonLike.Import.js
@@ -21,7 +21,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -84,7 +83,6 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_param_f64"] = function() {
                 return tmpParamF64s.pop();
             }
-
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_createTS2Skeleton"] = function bjs_createTS2Skeleton() {
                 try {
@@ -159,7 +157,7 @@ export async function createInstantiator(options, swift) {
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -167,9 +165,7 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-
             return {
-
             };
         },
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.Export.js
@@ -21,7 +21,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -84,13 +83,11 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_param_f64"] = function() {
                 return tmpParamF64s.pop();
             }
-
-
         },
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -98,7 +95,6 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-
             return {
                 throwsSomething: function bjs_throwsSomething() {
                     instance.exports.bjs_throwsSomething();

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TypeAlias.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TypeAlias.Import.js
@@ -21,7 +21,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -84,7 +83,6 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_param_f64"] = function() {
                 return tmpParamF64s.pop();
             }
-
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_checkSimple"] = function bjs_checkSimple(a) {
                 try {
@@ -97,7 +95,7 @@ export async function createInstantiator(options, swift) {
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -105,9 +103,7 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-
             return {
-
             };
         },
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TypeScriptClass.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TypeScriptClass.Import.js
@@ -21,7 +21,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -84,7 +83,6 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_param_f64"] = function() {
                 return tmpParamF64s.pop();
             }
-
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_Greeter_init"] = function bjs_Greeter_init(name) {
                 try {
@@ -145,7 +143,7 @@ export async function createInstantiator(options, swift) {
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -153,9 +151,7 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-
             return {
-
             };
         },
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.Export.js
@@ -21,7 +21,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -84,13 +83,11 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_param_f64"] = function() {
                 return tmpParamF64s.pop();
             }
-
-
         },
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -98,7 +95,6 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-
             return {
                 check: function bjs_check() {
                     instance.exports.bjs_check();

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.Import.js
@@ -21,7 +21,6 @@ export async function createInstantiator(options, swift) {
     let tmpParamInts = [];
     let tmpParamF32s = [];
     let tmpParamF64s = [];
-    
 
     return {
         /**
@@ -84,7 +83,6 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_param_f64"] = function() {
                 return tmpParamF64s.pop();
             }
-
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_check"] = function bjs_check() {
                 try {
@@ -97,7 +95,7 @@ export async function createInstantiator(options, swift) {
         setInstance: (i) => {
             instance = i;
             memory = instance.exports.memory;
-            
+
             setException = (error) => {
                 instance.exports._swift_js_exception.value = swift.memory.retain(error)
             }
@@ -105,9 +103,7 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-
             return {
-
             };
         },
     }


### PR DESCRIPTION
## Introduction
Migrating from "manual" code generation with the use of `.indent(count`, to using `CodeFragmentPrinter` within `BridgeJSLnk`.

## Notes
- split content of `link()` method as it was becoming a bit large and having lots of moving part as a result of adding new conditional sections for enums, etc
- separated TS and JS code generation within `link()` and encapsulated into individual functions for clarity
- as a side effect removed some empty lines from generated files which were mostly there due to conditional content that was inserted into """ and resulted in empty line if not present
- abstracted vars from `link()` into `LinkData` for clarity
- added some comments for JS / TS code generation to make it a bit easier to identify given segments of JS / TS generated files
- cleaned up unused old version of `renderGlobalNamespace`

Initially was biased to not split `let outputJs` as large """ seemed convenient, but eventually decided on refactoring this as well, as with more functionality added, it would become even more bloated 🙏🏻 