### PR TITLE
JavaScriptEventLoop: release the isSpinning latch before running jobs

### DIFF
--- a/Sources/JavaScriptEventLoop/JobQueue.swift
+++ b/Sources/JavaScriptEventLoop/JobQueue.swift
@@ -42,15 +42,19 @@ extension JavaScriptEventLoop {
 
     func runAllJobs() {
         assert(queueState.isSpinning)
-        // `defer`, so the latch is released even if a job throws.
+        // Release the latch BEFORE running any job, so `isSpinning` means "a
+        // drain microtask is pending" rather than "a drain is in progress".
         //
-        // `runSynchronously` can unwind — a Swift runtime trap, or (under
-        // JavaScriptKit specifically) a JS exception crossing back into wasm.
-        // Clearing `isSpinning` only by falling off the end of the loop leaves
-        // it latched `true` on that path, and `insertJobQueue` then never
-        // schedules another drain: the executor is dead for the lifetime of the
-        // process, silently.
-        defer { queueState.isSpinning = false }
+        // `runSynchronously` can unwind without running Swift cleanup — a
+        // runtime trap lowers to `unreachable`, and a JS exception crossing
+        // back into wasm unwinds the frames outright. Neither runs a `defer`.
+        // Clearing the latch only after the loop therefore leaves it stuck at
+        // `true` on those paths, and `insertJobQueue` never schedules another
+        // drain: the executor is dead for the lifetime of the process,
+        // silently. Clearing it up front costs one extra drain microtask per
+        // batch that enqueues, and an unwinding job leaves the queue merely
+        // undrained rather than unreachable — the next enqueue picks it up.
+        queueState.isSpinning = false
 
         while let job = self.claimNextFromQueue() {
             #if compiler(>=5.9)

--- a/Sources/JavaScriptEventLoop/JobQueue.swift
+++ b/Sources/JavaScriptEventLoop/JobQueue.swift
@@ -42,6 +42,15 @@ extension JavaScriptEventLoop {
 
     func runAllJobs() {
         assert(queueState.isSpinning)
+        // `defer`, so the latch is released even if a job throws.
+        //
+        // `runSynchronously` can unwind — a Swift runtime trap, or (under
+        // JavaScriptKit specifically) a JS exception crossing back into wasm.
+        // Clearing `isSpinning` only by falling off the end of the loop leaves
+        // it latched `true` on that path, and `insertJobQueue` then never
+        // schedules another drain: the executor is dead for the lifetime of the
+        // process, silently.
+        defer { queueState.isSpinning = false }
 
         while let job = self.claimNextFromQueue() {
             #if compiler(>=5.9)
@@ -50,8 +59,6 @@ extension JavaScriptEventLoop {
             job._runSynchronously(on: self.asUnownedSerialExecutor())
             #endif
         }
-
-        queueState.isSpinning = false
     }
 
     func claimNextFromQueue() -> UnownedJob? {


### PR DESCRIPTION
`JobQueue.runAllJobs()` clears `queueState.isSpinning` only as its final statement:

```swift
func runAllJobs() {
    assert(queueState.isSpinning)

    while let job = self.claimNextFromQueue() {
        job.runSynchronously(on: self.asUnownedSerialExecutor())
    }

    queueState.isSpinning = false   // ← not reached if a job unwinds
}
```

If `runSynchronously` unwinds, that line never runs and `isSpinning` stays `true`. `insertJobQueue` schedules a drain only when `!isSpinning`:

```swift
if !queueState.isSpinning {
    self.queueState.isSpinning = true
    JavaScriptEventLoop.shared.queueMicrotask { self.runAllJobs() }
}
```

So after a single unwound job the queue is **never drained again** — every later `enqueue` appends to a queue nothing will run, for the lifetime of the process.

### Why it is hard to spot

The failure is silent and total for async work while synchronous entry points keep behaving normally, so it presents as "async stopped" rather than as a crash. In a browser it is worse than that: `queueTask` is implemented as `promise.then { job() }`, so the escaping error rejects a **discarded** promise — it surfaces as an unhandled rejection, never as `window.onerror`. A page in this state answers every synchronous export perfectly and looks healthy.

### How we hit it

We ship a Swift/wasm app on JavaScriptKit 0.57.0. A trap inside a job (in our case an `AsyncAlgorithms` `merge` precondition, but the origin doesn't matter) left every Swift `Task` permanently dead while the module kept answering synchronous calls in ~4 ms. It cost us about nine days to attribute, because every measurement of the module said it was fine.

We confirmed the mechanism by injection with a control arm: one self-reverting throw from a host import → the next intent call times out at 21,986 ms; without it → 12 ms. We can share that harness if useful.

### The fix

Release the latch *before* the loop, so `isSpinning` means "a drain microtask is pending" rather than "a drain is in progress". An unwinding job then leaves the queue undrained but unlatched, and the next `insertJobQueue` schedules a fresh drain — including for jobs already queued behind it.

An earlier revision of this PR used `defer`. That was wrong: `defer` runs for a Swift `throw`, not for a wasm trap or a JS exception crossing back into wasm — the only two paths that strand the latch. Thanks to @kateinoigakukun for catching it.

Measured on a standalone repro (Node, no browser): enqueue one job that unwinds, then ask whether a `Task` enqueued afterwards ever runs. 5/5 runs per cell.

| JobQueue | control | JS exception | Swift trap |
|---|---|---|---|
| 0.57.0 as-is | alive | **dead** | **dead** |
| + `defer` | alive | **dead** | **dead** |
| release before the loop | alive | alive | alive |

Costs 2 extra drain microtasks per 20,000 `await` hops (work enqueued during a drain is consumed by the running loop without returning, so drains stay rare); no measurable wall-clock change. Existing suite unchanged: 194/194 XCTest + 13/13 swift-testing.

### On a regression test

There isn't one, deliberately. Fixed and unfixed differ only *under an unwind*, and an unwind is fatal to any in-process host: an XCTest case that throws through `runAllJobs` takes the Node process down and ~9 sibling tests with it, identically with and without the fix. Asserting the invariant directly doesn't work either — "isSpinning is false while a job runs" is false even when fixed, since any job that enqueues legitimately re-arms it.

A real test needs an out-of-process harness: build a fixture, run it under Node with a host that tolerates the escaping exception, assert a later `Task` still runs. That's a new shape for this repo (`Runtime/test` is JS-only against a stubbed instance; `Examples/*` are built but never executed), so I didn't want to invent it unasked. Happy to add one wherever you'd want it.

The same trailing-assignment pattern is in the unmerged `generalize-jobqueue` branch (`PriorityQueue.swift`), so it would ship again unless fixed there too.
