### PR TITLE
Runtime: Copy only the view's window in swjs_load_typed_array

### DIFF
--- a/Plugins/PackageToJS/Templates/runtime.mjs
+++ b/Plugins/PackageToJS/Templates/runtime.mjs
@@ -759,7 +759,12 @@ class SwiftRuntime {
             swjs_load_typed_array: (ref, buffer) => {
                 const memory = this.memory;
                 const typedArray = memory.getObject(ref);
-                const bytes = new Uint8Array(typedArray.buffer);
+                // Copy only the window the view describes. `typedArray.buffer`
+                // is the whole backing `ArrayBuffer`, which may be larger than
+                // the view and may start before it; the guest sizes the
+                // destination from the view's own length, so viewing the entire
+                // buffer would both shift the bytes and overrun the destination.
+                const bytes = new Uint8Array(typedArray.buffer, typedArray.byteOffset, typedArray.byteLength);
                 this.getUint8Array().set(bytes, buffer >>> 0);
             },
             swjs_release: (ref) => {

--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -763,7 +763,16 @@ export class SwiftRuntime {
             swjs_load_typed_array: (ref: ref, buffer: pointer) => {
                 const memory = this.memory;
                 const typedArray = memory.getObject(ref);
-                const bytes = new Uint8Array(typedArray.buffer);
+                // Copy only the window the view describes. `typedArray.buffer`
+                // is the whole backing `ArrayBuffer`, which may be larger than
+                // the view and may start before it; the guest sizes the
+                // destination from the view's own length, so viewing the entire
+                // buffer would both shift the bytes and overrun the destination.
+                const bytes = new Uint8Array(
+                    typedArray.buffer,
+                    typedArray.byteOffset,
+                    typedArray.byteLength,
+                );
                 this.getUint8Array().set(bytes, buffer >>> 0);
             },
 

--- a/Runtime/test/load-typed-array.test.ts
+++ b/Runtime/test/load-typed-array.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "vitest";
+import { SwiftRuntime } from "../src/index.js";
+
+// `swjs_load_typed_array` must copy only the window a TypedArray view describes,
+// not its whole backing `ArrayBuffer`. The guest sizes the destination from the
+// view's own `length`/`byteLength`, so copying the entire buffer both shifts the
+// bytes (a view with a non-zero `byteOffset` lands offset in the guest) and
+// writes past the end of the destination.
+const DESTINATION = 1024;
+
+function makeRuntime(): { runtime: SwiftRuntime; memory: WebAssembly.Memory } {
+    const memory = new WebAssembly.Memory({ initial: 1 });
+    const runtime = new SwiftRuntime();
+    runtime.setInstance({
+        exports: {
+            memory,
+            swjs_library_version: () => 708,
+        },
+    } as unknown as WebAssembly.Instance);
+    return { runtime, memory };
+}
+
+describe("swjs_load_typed_array respects the view's window", () => {
+    test("copies a Uint8Array view from its byteOffset", () => {
+        const { runtime, memory } = makeRuntime();
+        const backing = new ArrayBuffer(32);
+        new Uint8Array(backing).set(
+            Array.from({ length: 32 }, (_, i) => 0xa0 + i),
+        );
+        const view = new Uint8Array(backing, 8, 8);
+
+        const space = (runtime as any).memory;
+        const imports = runtime.wasmImports as any;
+        imports.swjs_load_typed_array(space.retain(view), DESTINATION);
+
+        const guest = new Uint8Array(memory.buffer);
+        expect(
+            Array.from(guest.subarray(DESTINATION, DESTINATION + 8)),
+        ).toEqual(Array.from(view));
+    });
+
+    test("does not write past the end of the view", () => {
+        const { runtime, memory } = makeRuntime();
+        const backing = new ArrayBuffer(32);
+        new Uint8Array(backing).fill(0xff);
+        const view = new Uint8Array(backing, 8, 8);
+
+        // Fill the guest memory around the destination with a sentinel so any
+        // byte written beyond the view's `byteLength` is visible.
+        const guest = new Uint8Array(memory.buffer);
+        guest.fill(0x5a, DESTINATION, DESTINATION + 64);
+
+        const space = (runtime as any).memory;
+        const imports = runtime.wasmImports as any;
+        imports.swjs_load_typed_array(space.retain(view), DESTINATION);
+
+        expect(
+            Array.from(guest.subarray(DESTINATION + 8, DESTINATION + 64)),
+        ).toEqual(new Array(56).fill(0x5a));
+    });
+
+    test("copies a multi-byte element view from its byteOffset", () => {
+        const { runtime, memory } = makeRuntime();
+        const backing = new ArrayBuffer(32);
+        new Int32Array(backing).set([1, 2, 3, 4, 5, 6, 7, 8]);
+        const view = new Int32Array(backing, 8, 4);
+
+        const space = (runtime as any).memory;
+        const imports = runtime.wasmImports as any;
+        imports.swjs_load_typed_array(space.retain(view), DESTINATION);
+
+        const guest = new Int32Array(memory.buffer, DESTINATION, 4);
+        expect(Array.from(guest)).toEqual([3, 4, 5, 6]);
+    });
+
+    test("copies a DataView from its byteOffset", () => {
+        const { runtime, memory } = makeRuntime();
+        const backing = new ArrayBuffer(32);
+        new Uint8Array(backing).set(
+            Array.from({ length: 32 }, (_, i) => 0xa0 + i),
+        );
+        const view = new DataView(backing, 8, 8);
+
+        const space = (runtime as any).memory;
+        const imports = runtime.wasmImports as any;
+        imports.swjs_load_typed_array(space.retain(view), DESTINATION);
+
+        const guest = new Uint8Array(memory.buffer);
+        expect(
+            Array.from(guest.subarray(DESTINATION, DESTINATION + 8)),
+        ).toEqual(Array.from(new Uint8Array(backing, 8, 8)));
+    });
+
+    test("still copies a whole-buffer view unchanged", () => {
+        const { runtime, memory } = makeRuntime();
+        const view = new Uint8Array([1, 2, 3, 4, 5]);
+
+        const space = (runtime as any).memory;
+        const imports = runtime.wasmImports as any;
+        imports.swjs_load_typed_array(space.retain(view), DESTINATION);
+
+        const guest = new Uint8Array(memory.buffer);
+        expect(
+            Array.from(guest.subarray(DESTINATION, DESTINATION + 5)),
+        ).toEqual([1, 2, 3, 4, 5]);
+    });
+});

--- a/Tests/JavaScriptKitTests/JSTypedArrayTests.swift
+++ b/Tests/JavaScriptKitTests/JSTypedArrayTests.swift
@@ -110,6 +110,84 @@ final class JSTypedArrayTests: XCTestCase {
         }
     }
 
+    func testTypedArrayWithByteOffset() {
+        // A view over part of a larger `ArrayBuffer`: `byteOffset` is non-zero and
+        // `byteLength` is smaller than the backing buffer. Copying the whole
+        // buffer instead of the view's window would both shift the bytes and
+        // write past the end of the destination, which is sized from `length`.
+        let backingLength = 32
+        let viewOffset = 8
+        let viewLength = 8
+
+        let arrayBuffer = JSObject.global.ArrayBuffer.function!.new(backingLength)
+        let wholeBuffer = JSTypedArray<UInt8>(
+            unsafelyWrapping: JSObject.global.Uint8Array.function!.new(arrayBuffer)
+        )
+        for i in 0..<backingLength {
+            wholeBuffer[i] = UInt8(0xA0 + i)
+        }
+
+        let view = JSTypedArray<UInt8>(
+            unsafelyWrapping: JSObject.global.Uint8Array.function!.new(
+                arrayBuffer,
+                viewOffset,
+                viewLength
+            )
+        )
+        XCTAssertEqual(view.length, viewLength)
+        XCTAssertEqual(view.lengthInBytes, viewLength)
+
+        let expected = (0..<viewLength).map { UInt8(0xA0 + viewOffset + $0) }
+        XCTAssertEqual(view.withUnsafeBytes { Array($0) }, expected)
+
+        // `copyMemory(to:)` must not write beyond the destination it is given.
+        let sentinel: UInt8 = 0x5A
+        let storage = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: backingLength)
+        defer { storage.deallocate() }
+        storage.initialize(repeating: sentinel)
+        let destination = UnsafeMutableBufferPointer(rebasing: storage[0..<viewLength])
+        view.copyMemory(to: destination)
+
+        XCTAssertEqual(Array(destination), expected)
+        for i in viewLength..<backingLength {
+            XCTAssertEqual(storage[i], sentinel, "copyMemory(to:) wrote past the destination at \(i)")
+        }
+    }
+
+    func testMultiByteTypedArrayWithByteOffset() {
+        // Same, with a multi-byte element type, so the destination is sized in
+        // elements while the overrun would be measured in bytes.
+        let elements: [Int32] = [1, 2, 3, 4, 5, 6, 7, 8]
+        let viewOffsetInBytes = 8
+        let viewLength = 4
+
+        let arrayBuffer = JSTypedArray<Int32>(elements).jsObject.buffer.object!
+        let view = JSTypedArray<Int32>(
+            unsafelyWrapping: JSObject.global.Int32Array.function!.new(
+                arrayBuffer,
+                viewOffsetInBytes,
+                viewLength
+            )
+        )
+        XCTAssertEqual(view.length, viewLength)
+        XCTAssertEqual(view.lengthInBytes, viewLength * MemoryLayout<Int32>.size)
+
+        let expected: [Int32] = [3, 4, 5, 6]
+        XCTAssertEqual(view.withUnsafeBytes { Array($0) }, expected)
+
+        let sentinel: Int32 = -559_038_737  // 0xDEADBEEF
+        let storage = UnsafeMutableBufferPointer<Int32>.allocate(capacity: elements.count)
+        defer { storage.deallocate() }
+        storage.initialize(repeating: sentinel)
+        let destination = UnsafeMutableBufferPointer(rebasing: storage[0..<viewLength])
+        view.copyMemory(to: destination)
+
+        XCTAssertEqual(Array(destination), expected)
+        for i in viewLength..<elements.count {
+            XCTAssertEqual(storage[i], sentinel, "copyMemory(to:) wrote past the destination at \(i)")
+        }
+    }
+
     func testCopyMemory() {
         let array = JSTypedArray<Int>(length: 100)
         for i in 0..<100 {


### PR DESCRIPTION
## The bug

`swjs_load_typed_array` views the whole backing `ArrayBuffer` instead of the window the view it was handed describes:

```ts
swjs_load_typed_array: (ref: ref, buffer: pointer) => {
    const memory = this.memory;
    const typedArray = memory.getObject(ref);
    const bytes = new Uint8Array(typedArray.buffer);   // <- ignores byteOffset/byteLength
    this.getUint8Array().set(bytes, buffer >>> 0);
},
```

`typedArray.buffer` is the backing `ArrayBuffer`, which may be larger than the view and may start before it. Any view produced by `subarray` or `new Uint8Array(buffer, offset, length)` has a non-zero `byteOffset`, and the copy ignores it.

### Minimal repro

```swift
let backing = JSObject.global.ArrayBuffer.function!.new(32)
let whole = JSTypedArray<UInt8>(unsafelyWrapping: JSObject.global.Uint8Array.function!.new(backing))
for i in 0..<32 { whole[i] = UInt8(0xA0 + i) }

// A view over bytes 8..<16 of that buffer.
let view = JSTypedArray<UInt8>(
    unsafelyWrapping: JSObject.global.Uint8Array.function!.new(backing, 8, 8)
)

print(view.withUnsafeBytes { Array($0) })
// expected: [0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0xAF]
// actual:   [0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7]
```

The bytes come back shifted by `byteOffset`. Nothing throws — the result is just quietly wrong, which is what makes this class of bug expensive to find downstream.

## Why this is a memory-safety issue, not only a correctness one

The guest sizes the destination from the *view's* element count, never from the backing buffer:

- `Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift` — `length` is `jsObject["length"]`, the view's element count.
- `copyMemory(to:)` preconditions only `buffer.count >= length` before calling `swjs_load_typed_array`.
- `withUnsafeBytes` / `withUnsafeBytesAsync` allocate exactly `capacity: length`.

So whenever the view is smaller than its backing buffer, JavaScript writes `buffer.byteLength` bytes into a destination sized for `view.byteLength`. The excess lands in whatever follows the destination in linear memory. The `precondition` cannot catch it — it is satisfied, and the overrun happens on the JS side of the boundary. There is no error, no trap, and no diagnostic; just corrupted memory after the buffer.

It is reachable from ordinary API use: `JSTypedArray(unsafelyWrapping:)` over any JS-side view, or a `Uint8Array` handed in from JavaScript that happens to be a `subarray`.

## The fix

Respect the view's window:

```ts
const bytes = new Uint8Array(
    typedArray.buffer,
    typedArray.byteOffset,
    typedArray.byteLength,
);
```

This is the generic solution for every element type the runtime supports — all `TypedArray` types and `DataView` expose `byteOffset` and `byteLength`, and for a whole-buffer view (the common case, and everything `swjs_create_typed_array` produces) it is `(buffer, 0, buffer.byteLength)`, identical to today's behaviour.

### Follow-up not included here

The runtime still trusts that the guest sized the destination correctly; it has no way to know how many bytes the caller allocated. A defensive bounds check would need the length plumbed through the `swjs_load_typed_array` ABI, which is a larger change than this fix warrants, so it is left out deliberately. Worth considering separately if the ABI is revised.

## Testing

`Plugins/PackageToJS/Templates/runtime.mjs` was regenerated with `make regenerate_swiftpm_resources`, not hand-edited; its diff is exactly the change to `Runtime/src/index.ts`. `runtime.d.ts` is unchanged (no type surface change).

New tests, both of which fail before the fix and pass after:

- `Runtime/test/load-typed-array.test.ts` — drives `swjs_load_typed_array` against a real `WebAssembly.Memory`, following the pattern in `pointer-normalization.test.ts`. Covers `Uint8Array` and `Int32Array` views with a non-zero `byteOffset`, a `DataView`, the no-overrun property (guest memory past the view's `byteLength` must keep its sentinel), and a whole-buffer view as a control.

  Before the fix: 4 failed, 1 passed (the whole-buffer control). After: 5 passed.

- `Tests/JavaScriptKitTests/JSTypedArrayTests.swift` — `testTypedArrayWithByteOffset` and `testMultiByteTypedArrayWithByteOffset` assert the same two properties through the Swift API: correct bytes via `withUnsafeBytes`, and that `copyMemory(to:)` leaves sentinel values past the destination untouched.

  With the runtime reverted to `new Uint8Array(typedArray.buffer)`: `194 passed, 2 failed, 196 total`, and the overrun assertions name the corrupted slots directly (`copyMemory(to:) wrote past the destination at 8` … `at 31`). With the fix: `196 passed, 196 total`.

Ran locally: `npm run test:runtime`, `npx prettier --check Runtime/src`, `npm run check:bridgejs-dts`, `./Utilities/format.swift` (no changes), `swift test --package-path ./Plugins/PackageToJS`, `swift test --package-path ./Plugins/BridgeJS`, and `make unittest BUILD_SYSTEM=native` against a `wasm32-unknown-wasip1` SDK (all suites pass, including `JSTypedArrayTests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
